### PR TITLE
Added support for advanced floating decorations

### DIFF
--- a/src/XMonad/Config.hs
+++ b/src/XMonad/Config.hs
@@ -28,11 +28,11 @@ module XMonad.Config (defaultConfig, Default(..)) where
 import XMonad.Core as XMonad hiding
     (workspaces,manageHook,keys,logHook,startupHook,borderWidth,mouseBindings
     ,layoutHook,modMask,terminal,normalBorderColor,focusedBorderColor,focusFollowsMouse
-    ,handleEventHook,clickJustFocuses,rootMask,clientMask)
+    ,handleEventHook,clickJustFocuses,focusRaisesFloat,floatFocusFollowsMouse,clientMask,rootMask)
 import qualified XMonad.Core as XMonad
     (workspaces,manageHook,keys,logHook,startupHook,borderWidth,mouseBindings
     ,layoutHook,modMask,terminal,normalBorderColor,focusedBorderColor,focusFollowsMouse
-    ,handleEventHook,clickJustFocuses,rootMask,clientMask)
+    ,handleEventHook,clickJustFocuses,focusRaisesFloat,floatFocusFollowsMouse,clientMask,rootMask)
 
 import XMonad.Layout
 import XMonad.Operations
@@ -147,6 +147,9 @@ layout = tiled ||| Mirror tiled ||| Full
      -- Percent of screen to increment by when resizing panes
      delta   = 3/100
 
+-- |  the decorations applied o floating windows
+floatDecorator :: FloatDec Window
+floatDecorator = noFloatDec
 ------------------------------------------------------------------------
 -- Event Masks:
 
@@ -171,6 +174,14 @@ terminal = "xterm"
 -- | Whether focus follows the mouse pointer.
 focusFollowsMouse :: Bool
 focusFollowsMouse = True
+
+-- | Whether focus follows the mouse pointer for floating windows
+floatFocusFollowsMouse :: Bool
+floatFocusFollowsMouse = False
+
+-- | Whether clicking a floating window raises it
+focusRaisesFloat :: Bool
+focusRaisesFloat = True
 
 -- | Whether a mouse click select the focus or is just passed to the window
 clickJustFocuses :: Bool
@@ -254,26 +265,29 @@ mouseBindings (XConfig {XMonad.modMask = modMask}) = M.fromList
 
 instance (a ~ Choose Tall (Choose (Mirror Tall) Full)) => Default (XConfig a) where
   def = XConfig
-    { XMonad.borderWidth        = borderWidth
-    , XMonad.workspaces         = workspaces
-    , XMonad.layoutHook         = layout
-    , XMonad.terminal           = terminal
-    , XMonad.normalBorderColor  = normalBorderColor
-    , XMonad.focusedBorderColor = focusedBorderColor
-    , XMonad.modMask            = defaultModMask
-    , XMonad.keys               = keys
-    , XMonad.logHook            = logHook
-    , XMonad.startupHook        = startupHook
-    , XMonad.mouseBindings      = mouseBindings
-    , XMonad.manageHook         = manageHook
-    , XMonad.handleEventHook    = handleEventHook
-    , XMonad.focusFollowsMouse  = focusFollowsMouse
+    { XMonad.borderWidth            = borderWidth
+    , XMonad.workspaces             = workspaces
+    , XMonad.layoutHook             = layout
+    , XMonad.floatHook              = floatDecorator
+    , XMonad.terminal               = terminal
+    , XMonad.normalBorderColor      = normalBorderColor
+    , XMonad.focusedBorderColor     = focusedBorderColor
+    , XMonad.modMask                = defaultModMask
+    , XMonad.keys                   = keys
+    , XMonad.logHook                = logHook
+    , XMonad.startupHook            = startupHook
+    , XMonad.mouseBindings          = mouseBindings
+    , XMonad.manageHook             = manageHook
+    , XMonad.handleEventHook        = handleEventHook
+    , XMonad.focusFollowsMouse      = focusFollowsMouse
+    , XMonad.floatFocusFollowsMouse = floatFocusFollowsMouse
     , XMonad.clickJustFocuses       = clickJustFocuses
-    , XMonad.clientMask         = clientMask
-    , XMonad.rootMask           = rootMask
+    , XMonad.focusRaisesFloat       = focusRaisesFloat
+    , XMonad.clientMask             = clientMask
+    , XMonad.rootMask               = rootMask
     , XMonad.handleExtraArgs = \ xs theConf -> case xs of
-                [] -> return theConf
-                _ -> fail ("unrecognized flags:" ++ show xs)
+                    [] -> return theConf
+                    _ -> fail ("unrecognized flags:" ++ show xs)
     }
 
 -- | The default set of configuration values itself

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -23,8 +23,11 @@ module XMonad.Core (
     Layout(..), readsLayout, Typeable, Message,
     SomeMessage(..), fromMessage, LayoutMessages(..),
     StateExtension(..), ExtensionClass(..),
+    FLayer(..), FloatClass(..), FloatDec(..), noFloatDec,
+    insertFDec, deleteByDec, newFDec, deleteByOrig, NoFloatDec(..),
     runX, catchX, userCode, userCodeDef, io, catchIO, installSignalHandlers, uninstallSignalHandlers,
-    withDisplay, withWindowSet, isRoot, runOnWorkspaces,
+    withDisplay, withWindowSet, withFLayer, 
+    isRoot, runOnWorkspaces, modifyFLayer,
     getAtom, spawn, spawnPID, xfork, getXMonadDir, recompile, trace, whenJust, whenX,
     atom_WM_STATE, atom_WM_PROTOCOLS, atom_WM_DELETE_WINDOW, atom_WM_TAKE_FOCUS, ManageHook, Query(..), runQuery
   ) where
@@ -65,6 +68,7 @@ data XState = XState
     , waitingUnmap     :: !(M.Map Window Int)            -- ^ the number of expected UnmapEvents
     , dragging         :: !(Maybe (Position -> Position -> X (), X ()))
     , numberlockMask   :: !KeyMask                       -- ^ The numlock modifier
+    , floatingLayer     :: !(FLayer Window)
     , extensibleState  :: !(M.Map String (Either String StateExtension))
     -- ^ stores custom state information.
     --
@@ -97,6 +101,7 @@ data XConfig l = XConfig
     , focusedBorderColor :: !String              -- ^ Focused windows border color. Default: \"#ff0000\"
     , terminal           :: !String              -- ^ The preferred terminal application. Default: \"xterm\"
     , layoutHook         :: !(l Window)          -- ^ The available layouts
+    , floatHook          :: !(FloatDec Window)
     , manageHook         :: !ManageHook          -- ^ The action to run when a new window is opened
     , handleEventHook    :: !(Event -> X All)    -- ^ Handle an X event, returns (All True) if the default handler
                                                  -- should also be run afterwards. mappend should be used for combining
@@ -111,6 +116,8 @@ data XConfig l = XConfig
     , logHook            :: !(X ())              -- ^ The action to perform when the windows set is changed
     , startupHook        :: !(X ())              -- ^ The action to perform on startup
     , focusFollowsMouse  :: !Bool                -- ^ Whether window entry events can change focus
+    , floatFocusFollowsMouse  :: !Bool                -- ^ Whether window entry events can change focus in the floating layer
+    , focusRaisesFloat   :: !Bool                -- ^ Whether focus raises thea float
     , clickJustFocuses   :: !Bool                -- ^ False to make a click which changes focus to be additionally passed to the window
     , clientMask         :: !EventMask           -- ^ The client events that xmonad is interested in
     , rootMask           :: !EventMask           -- ^ The root events that xmonad is interested in
@@ -201,7 +208,11 @@ userCodeDef defValue a = fromMaybe defValue `liftM` userCode a
 
 -- | Run a monad action with the current display settings
 withDisplay :: (Display -> X a) -> X a
-withDisplay   f = asks display >>= f
+withDisplay f = asks display >>= f
+
+-- | Run a monad action with the current floating layer
+withFLayer :: (FLayer Window -> X a) -> X a
+withFLayer f = gets floatingLayer >>= f
 
 -- | Run a monadic action with the current stack set
 withWindowSet :: (WindowSet -> X a) -> X a
@@ -529,3 +540,116 @@ uninstallSignalHandlers = io $ do
     installHandler openEndedPipe Default Nothing
     installHandler sigCHLD Default Nothing
     return ()
+
+--------------------------------------------------------------------
+-- Float Layer data support  
+--------------------------------------------------------------------
+
+-- | Existential type for the floating decorations
+data FloatDec a = forall fc. (FloatClass fc a) => FloatDec (fc a)
+
+-- | the data the floating layer needs in order to function
+data FLayer a = FLayer 
+    { -- map from the floating wins to their decorations, 
+      -- Nothing means the window should not be decorated
+      fWins :: M.Map a (Maybe a)
+      -- map from the decorations to their parent windows
+    , decWins :: M.Map a a
+      -- the Floating decorator
+    , fDec ::  FloatDec a
+    } 
+
+-- | given a decoration window, remove it and it's parent from the floating layer
+deleteByDec:: Ord a => a -> FLayer a -> FLayer a
+deleteByDec dw f@(FLayer fws dcs fd) = case M.lookup dw dcs of
+    Just fw -> FLayer (M.delete fw fws) (M.delete dw dcs) fd
+    otherwise -> f
+
+-- | given a floating window, remove it and it's decoration from the floating layer
+deleteByOrig :: Ord a => a -> FLayer a -> FLayer a
+deleteByOrig ow f@(FLayer fws dcs fd) = case M.lookup ow fws of
+    -- The window is decorated, remove the decoration
+    Just (Just dw) -> FLayer (M.delete ow fws) (M.delete dw dcs) fd
+    -- The window is not decorated
+    Just _ -> FLayer (M.delete ow fws) dcs fd 
+    -- Something funny is happening, just ignore it
+    otherwise -> f
+
+-- | add a given window and maybe it's decoration to the floating layer
+insertFDec :: Ord a => a -> Maybe a -> FLayer a -> FLayer a
+insertFDec ow Nothing (FLayer fs ds fd) = FLayer (M.insert ow Nothing fs) ds fd
+insertFDec ow (Just dw) (FLayer fs ds fd) = 
+    let fs' = M.insert ow (Just dw) fs
+        ds' = M.insert dw ow ds 
+    in FLayer fs' ds' fd
+
+-- | replace the floating layer's decorator
+newFDec :: Maybe (FloatDec a) -> FLayer a -> FLayer a
+newFDec (Just fd) fl = fl {fDec = fd}
+newFDec Nothing fl = fl
+
+-- | convinience wrapper for changes to the floating layer
+modifyFLayer :: (FLayer Window -> FLayer Window) -> X ()
+modifyFLayer f = modify $ \s -> s{floatingLayer = f $ floatingLayer s}
+
+-- | All floating decorations must be instances of this class, none of
+-- the functions need to be implemented
+class FloatClass fc a where
+    -- | handle a some message
+    handleFloatMessage :: fc a -> SomeMessage -> X (Maybe (fc a))
+    handleFloatMessage _ _ = return Nothing
+    
+    -- | Given a window create a new one or return Nothing if the
+    -- window should not be decorated
+    -- | You are are responsible for making sure the window is shown
+    createFDec :: fc a -> a -> X (Maybe a, Maybe (fc a))
+    createFDec _ _ = return (Nothing, Nothing)
+
+    -- | called whenever the parent window is resized or moved
+    -- adjust, the decoration to match
+    moveFDec :: fc a -> a -> a -> X (Maybe (fc a))
+    moveFDec _ _ _ = return Nothing
+
+    -- | called whenever the parent window is hidden. The decoration
+    -- window will be automatically hidden, but not until after this
+    -- function is called
+    hideFDec :: fc a -> a -> a -> X (Maybe (fc a))
+    hideFDec _ _ _ = return Nothing
+
+    -- | called when the parent window is sunk or destroyed. The
+    -- decoration will be automatically destroyed after this function is called
+    removeFDec :: fc a -> a -> a -> X (Maybe (fc a))
+    removeFDec _ _ _ = return Nothing
+
+    -- | called before a parent is about to be dragged, prepare the
+    -- decoration window
+    startDecDrag :: fc a -> a -> a -> X (Maybe (fc a))
+    startDecDrag _ _ _ = return Nothing
+
+    -- | a function that allows a decoration window to respond to changes to
+    -- it's parent window by a dragging function. Return a function that will
+    -- adjust the decoration window in accordance with the parent's new size
+    whileDecDrag :: fc a -> a -> a -> X (Rectangle -> X ())
+    whileDecDrag _ _ _ = return $ \_ -> return ()
+
+    -- | called when the parent is done being dragged
+    finishDecDrag :: fc a -> a -> a -> X (Maybe (fc a))
+    finishDecDrag _ _ _ = return Nothing
+
+-- | default floating layer, no decorations
+data NoFloatDec a = NoFloatDec 
+instance FloatClass NoFloatDec a
+
+--- | return the default floating layer wrapped in a FloatDec
+noFloatDec :: FloatDec Window
+noFloatDec = FloatDec NoFloatDec
+
+instance FloatClass FloatDec Window where
+    handleFloatMessage (FloatDec f)  m = fmap FloatDec <$> handleFloatMessage f m
+    createFDec (FloatDec f) dw  = fmap (fmap FloatDec) <$>  createFDec f dw
+    moveFDec (FloatDec f) ow dw = fmap FloatDec <$> moveFDec f ow dw
+    hideFDec (FloatDec f) ow dw = fmap FloatDec <$> hideFDec f ow dw
+    removeFDec (FloatDec f) ow dw = fmap FloatDec <$> removeFDec f ow dw
+    startDecDrag (FloatDec f) ow dw = fmap FloatDec <$> startDecDrag f ow dw
+    finishDecDrag (FloatDec f) ow dw = fmap FloatDec <$> finishDecDrag f ow dw
+    whileDecDrag (FloatDec f) = whileDecDrag f 

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -187,6 +187,7 @@ xmonadNoargs initxmc serializedWinset serializedExtstate = do
     hSetBuffering stdout NoBuffering
 
     let layout = layoutHook xmc
+        floatDec = floatHook xmc
         lreads = readsLayout layout
         initialWinset = let padToLen n xs = take (max n (length xs)) $ xs ++ repeat ""
             in new layout (padToLen (length xinesc) (workspaces xmc)) $ map SD xinesc
@@ -222,6 +223,7 @@ xmonadNoargs initxmc serializedWinset serializedExtstate = do
             , mapped          = S.empty
             , waitingUnmap    = M.empty
             , dragging        = Nothing
+            , floatingLayer   = FLayer M.empty M.empty floatDec
             , extensibleState = extState
             }
     allocaXEvent $ \e ->
@@ -356,7 +358,11 @@ handle e@(ButtonEvent {ev_window = w,ev_event_type = t,ev_button = b })
 -- True in the user's config.
 handle e@(CrossingEvent {ev_window = w, ev_event_type = t})
     | t == enterNotify && ev_mode   e == notifyNormal
-    = whenX (asks $ focusFollowsMouse . config) (focus w)
+    = do 
+        ws <- gets windowset
+        if M.member w (W.floating ws)
+            then whenX (asks $ floatFocusFollowsMouse . config) (focus w)
+            else whenX (asks $ focusFollowsMouse . config) (focus w)
 
 -- left a window, check if we need to focus root
 handle e@(CrossingEvent {ev_event_type = t})
@@ -465,6 +471,8 @@ grabButtons = do
     let grab button mask = io $ grabButton dpy button mask rootw False buttonPressMask
                                            grabModeAsync grabModeSync none none
     io $ ungrabButton dpy anyButton anyModifier rootw
+    io $ grabButton dpy button1 noModMask rootw True buttonPressMask grabModeSync
+            grabModeSync none none
     ems <- extraModifiers
     ba <- asks buttonActions
     mapM_ (\(m,b) -> mapM_ (grab b . (m .|.)) ems) (M.keys $ ba)


### PR DESCRIPTION
I made some tweaks to the core functionality of XMonad to allow developers to create more advanced floating window decorations that can be used to drag windows and resize them. Here is a [gif](http://i.imgur.com/6J8jzho.gif) of this extension can being used along with a contrib module (submitted in a second pull request) that provides the actual decorations. 

This change adds new fields to the `XConfig` and `XState` datatypes and could potentially break user configs that do not use `def` values. However all the modules in contrib compile fine.

I have been using this extension for over a year now and have never had problems with it. This is my first ever pull request so please let me know if you need more information or anything from my end and I'll be happy to help.
