### PR TITLE
Fallback onto /etc/xmonad

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -431,9 +431,12 @@ runOnWorkspaces job = do
              $ current ws : visible ws
     modify $ \s -> s { windowset = ws { current = c, visible = v, hidden = h } }
 
--- | Return the path to @~\/.xmonad@.
+-- | Return the path to @~\/.xmonad@ if it exists, otherwise use @\/etc\/xmonad@.
 getXMonadDir :: MonadIO m => m String
-getXMonadDir = io $ getAppUserDataDirectory "xmonad"
+getXMonadDir = io $ do e <- userExists; if e then user else (return "/etc/xmonad")
+  where
+  user = getAppUserDataDirectory "xmonad"
+  userExists = user >>= doesDirectoryExist
 
 -- | 'recompile force', recompile @~\/.xmonad\/xmonad.hs@ when any of the
 -- following apply:


### PR DESCRIPTION
I would like to place my `xmonad.hs` in a global folder (outside `~/.xmonad`). This patch would allow for the file to exist in `/etc/xmonad` instead.

The patch does not have any impact (from what I can tell) on existing XMonad configurations.
It merely offers a fallback mechanism, should `~/.xmonad` not exist (other than `def`).

This relates to NixOS/nixpkgs#20260