### PR TITLE
only turn on -prof -auto-all with profiling flag

### DIFF
--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -49,6 +49,11 @@ flag generatemanpage
     default: False
     manual: True
 
+flag profiling
+     description: Enable profiling
+     default: False
+     manual: True
+
 library
     hs-source-dirs:     src
     exposed-modules:    XMonad
@@ -84,7 +89,8 @@ library
         -- needed for XMonad.Config's instance Default (XConfig a)
 
 
-    ghc-prof-options:   -prof -auto-all
+    if flag(profiling)
+        ghc-prof-options:   -prof -auto-all
 
     if flag(testing)
         buildable: False


### PR DESCRIPTION
I just enabled GHC 8 in our Travis tests, and it fails because `cabal check` fails with this error:

```
These warnings may cause trouble when distributing the package:
* 'ghc-options: -fprof*' profiling flags are typically not appropriate for a
distributed library package. These flags are useful to profile this package,
but when profiling other packages that use this one these flags clutter the
profile output with excessive detail. If you think other packages really want
to see cost centres from this package then use '-fprof-auto-exported' which
puts cost centres only on exported functions. Alternatively, if you want to
use this, make it conditional based on a Cabal configuration flag (with
'manual: True' and 'default: False') and enable that flag during development.
```

I don't know why we had `-prof` `-auto-all` enabled by default, so I propose hiding them behind a cabal flag called `profiling`, as suggested in the above message.  Any thoughts, comments, or objections welcome.  If no one cares then I will eventually merge this.