### PR TITLE
cabal: set 'testing' flag to manual

### DIFF
--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -43,6 +43,7 @@ source-repository head
 flag testing
     description: Testing mode, only build minimal components
     default: False
+    manual: True
 
 flag generatemanpage
     description: Build the tool for generating the man page


### PR DESCRIPTION
@hvr asked on IRC why the `testing` flag is not marked as `manual` (which means the cabal solver is free to set or unset it to resolve dependencies).  I see no reason why it should not be `manual`.  Does anyone else know of a reason?  Or is this just historical cruft?