### PR TITLE
Fetch border color from the window's colormap

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -26,7 +26,8 @@ module XMonad.Core (
     runX, catchX, userCode, userCodeDef, io, catchIO, installSignalHandlers, uninstallSignalHandlers,
     withDisplay, withWindowSet, isRoot, runOnWorkspaces,
     getAtom, spawn, spawnPID, xfork, getXMonadDir, recompile, trace, whenJust, whenX,
-    atom_WM_STATE, atom_WM_PROTOCOLS, atom_WM_DELETE_WINDOW, atom_WM_TAKE_FOCUS, ManageHook, Query(..), runQuery
+    atom_WM_STATE, atom_WM_PROTOCOLS, atom_WM_DELETE_WINDOW, atom_WM_TAKE_FOCUS, withWindowAttributes,
+    ManageHook, Query(..), runQuery
   ) where
 
 import XMonad.StackSet hiding (modify)
@@ -49,7 +50,7 @@ import System.Process
 import System.Directory
 import System.Exit
 import Graphics.X11.Xlib
-import Graphics.X11.Xlib.Extras (Event)
+import Graphics.X11.Xlib.Extras (getWindowAttributes, WindowAttributes, Event)
 import Data.Typeable
 import Data.List ((\\))
 import Data.Maybe (isJust,fromMaybe)
@@ -206,6 +207,12 @@ withDisplay   f = asks display >>= f
 -- | Run a monadic action with the current stack set
 withWindowSet :: (WindowSet -> X a) -> X a
 withWindowSet f = gets windowset >>= f
+
+-- | Safely access window attributes.
+withWindowAttributes :: Display -> Window -> (WindowAttributes -> X ()) -> X ()
+withWindowAttributes dpy win f = do
+    wa <- userCode (io $ getWindowAttributes dpy win)
+    catchX (whenJust wa f) (return ())
 
 -- | True if the given window is the root window
 isRoot :: Window -> X Bool

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -78,7 +78,7 @@ library
                    process,
                    unix,
                    utf8-string >= 0.3 && < 1.1,
-                   X11>=1.5 && < 1.7
+                   X11>=1.7 && < 1.8
 
     if true
         ghc-options:        -funbox-strict-fields -Wall


### PR DESCRIPTION
This is a (slightly refactored) patch from Adam Sjøgren (@asjo) which improves upon and completes xmonad/xmonad#9.

There are two important things going on in this PR:

  1. The X11 library was recently updated to correctly throw an exception when `getWindowAttributes` fails.  This PR updates most of the core xmonad calls into `getWindowAttributes` to avoid crashing when an exception is thrown.

  2. When a window is a true RGBA window, and a compositor is running, xmonad will incorrectly draw semi-transparent window borders on that window.  This PR updates xmonad to fetch the border colors from the window's colormap (if there is one) in order to correctly set the border color.