### PR TITLE
fix #63: window jumping to origin position when dragging

### DIFF
--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -515,8 +515,11 @@ mouseMoveWindow w = whenX (isClient w) $ withDisplay $ \d -> do
     (_, _, _, ox', oy', _, _, _) <- io $ queryPointer d w
     let ox = fromIntegral ox'
         oy = fromIntegral oy'
-    mouseDrag (\ex ey -> io $ moveWindow d w (fromIntegral (fromIntegral (wa_x wa) + (ex - ox)))
-                                             (fromIntegral (fromIntegral (wa_y wa) + (ey - oy))))
+    mouseDrag (\ex ey -> do
+                  io $ moveWindow d w (fromIntegral (fromIntegral (wa_x wa) + (ex - ox)))
+                                      (fromIntegral (fromIntegral (wa_y wa) + (ey - oy)))
+                  float w
+              )
               (float w)
 
 -- | resize the window under the cursor with the mouse while it is dragged
@@ -526,10 +529,12 @@ mouseResizeWindow w = whenX (isClient w) $ withDisplay $ \d -> do
     wa <- io $ getWindowAttributes d w
     sh <- io $ getWMNormalHints d w
     io $ warpPointer d none w 0 0 0 0 (fromIntegral (wa_width wa)) (fromIntegral (wa_height wa))
-    mouseDrag (\ex ey ->
+    mouseDrag (\ex ey -> do
                  io $ resizeWindow d w `uncurry`
                     applySizeHintsContents sh (ex - fromIntegral (wa_x wa),
-                                               ey - fromIntegral (wa_y wa)))
+                                               ey - fromIntegral (wa_y wa))
+                 float w)
+
               (float w)
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
We need to make sure that the StackSet contains the right
position for the window at all times while dragging. Previously,
the window was only placed at a different position. If, for any
reason, a layout refresh happens while the window is being dragged,
then the window will jump back to the old position because the StackSet
still contains the position of the window where it was as the drag started.

This patch fixes that issue by calling float after each mouse movement, which
ensures that the position for the window is updated in the StackSet.

Fixes #63