### PR TITLE
Don't send focus events for the wrong windows

### DIFF
--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -357,7 +357,11 @@ handle e@(ButtonEvent {ev_window = w,ev_event_type = t,ev_button = b })
 -- True in the user's config.
 handle e@(CrossingEvent {ev_window = w, ev_event_type = t})
     | t == enterNotify && ev_mode   e == notifyNormal
-    = whenX (asks $ focusFollowsMouse . config) (focus w)
+    = whenX (asks $ focusFollowsMouse . config) $ do
+        dpy <- asks display
+        root <- asks theRoot
+        (_, _, w', _, _, _, _, _) <- io $ queryPointer dpy root
+        when (w == w') (focus w)
 
 -- left a window, check if we need to focus root
 handle e@(CrossingEvent {ev_event_type = t})


### PR DESCRIPTION
I'm seeing an occasional focus switching loop after rapid mouse movements when UpdatePointer is used with focusFollowsMouse=True. After moving the pointer back and forth between two windows, or a linear movement across the corners of three, the pointer flickers very quickly between two of the windows until I press super-tab. It looks like UpdatePointer is reacting to an event that's one frame behind the actual mouse pointer.

I found this patch on XMonad's old Google Code site (see below), which adds an additional sanity check to make sure the pointer is still in the window before generating the focus event, and after testing it the problem seems to be fixed.

Originally from https://code.google.com/archive/p/xmonad/issues/200 comment 2