### PR TITLE
Rare crash fix due to uncaught exception from `getWindowAttributes`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,8 @@
     Fixes #8.  (Second way to have a custom build environment for
     XMonad.  See previous entry for another solution.)
 
+  * Fixed a crash related to an unhandled getWindowAttributes exception
+
 ## 0.12 (December 14, 2015)
 
   * Compiles with GHC 7.10.2, 7.8.4, and 7.6.3

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -632,8 +632,12 @@ type D = (Dimension, Dimension)
 mkAdjust :: Window -> X (D -> D)
 mkAdjust w = withDisplay $ \d -> liftIO $ do
     sh <- getWMNormalHints d w
-    bw <- fmap (fromIntegral . wa_border_width) $ getWindowAttributes d w
-    return $ applySizeHints bw sh
+    wa <- C.try $ getWindowAttributes d w
+    case wa of
+         Left  err -> const (return id) (err :: C.SomeException)
+         Right wa' ->
+            let bw = fromIntegral $ wa_border_width wa'
+            in  return $ applySizeHints bw sh
 
 -- | Reduce the dimensions if needed to comply to the given SizeHints, taking
 -- window borders into account.


### PR DESCRIPTION
### Description

I was getting some very strange crashes which I could only reproduce reliably on my desktop machine (but e.g. not on my laptop which is running a very similar setup), so I'm still not entirely sure what exactly triggered it. However, after much headscratching, I managed to track the error message down to this `getWindowAttributes` call which doesn't check for exceptions. The attached patch adds a minimal "sane default" for when the call fails, which fixed the crashing for me.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing) _Given the nature of the issue and of my changes, I don't think using various configs from `xmonad-testing` will provide any meaningful results, but I'll happily catch up on that if requested._

  - [X] I updated the `CHANGES.md` file
