### PR TITLE
fix xmonad/xmonad#87

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@
     - Focus did not follow when moving between workspaces (#87)
     - etc.
 
+  * Recover old behavior (in 0.12) when `focusFollowsMouse == True`:
+    the focus follows when the mouse enters another workspace
+    but not moving into any window.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -368,7 +368,9 @@ handle e@(CrossingEvent {ev_window = w, ev_event_type = t})
         dpy <- asks display
         root <- asks theRoot
         (_, _, w', _, _, _, _, _) <- io $ queryPointer dpy root
-        when (w == w') (focus w)
+        -- when Xlib cannot find a child that contains the pointer,
+        -- it returns None(0)
+        when (w' == 0 || w == w') (focus w)
 
 -- left a window, check if we need to focus root
 handle e@(CrossingEvent {ev_event_type = t})


### PR DESCRIPTION
### Description

Fix #87. Switch focus when mouse enters a workspace but not moving into a window (w' = 0).

Attempted to preserve the old fix (https://github.com/xmonad/xmonad/commit/3a140badf52a7ce5676a3dc240265be136593f9c) while recover the intended behavior.

However I can only say for sure that this works for me:

- I tried to follow the discussion found in https://github.com/xmonad/xmonad/commit/3a140badf52a7ce5676a3dc240265be136593f9c, but that's a very old thread and many people had reported not reproducing the bug so I don't bother testing it
- attempted `xmonad-testing`, can confirm nothing beyond that there's no problem with default config, the bug occurs only when you have more than one monitor and I have no idea how could xephyr simulate an environment like that.

Also updated `CHANGES.md`, but can't come up with a more concise and clear description, so suggestions on that is also welcomed.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] ~~I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)~~ (tested with default settings (`main = xmonad def`) on my own machine (see comment below))

  - [x] I updated the `CHANGES.md` file
