### PR TITLE
Remove the xmonad state file after reading it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,19 @@
 # Change Log / Release Notes
 
+## 0.14 (Not Yet Released)
+
+### Bug Fixes
+
+  * The state file that xmonad uses while restarting itself is now
+    removed after it is processed.  This fixes a bug that manifested
+    in several different ways:
+
+    - Names of old workspaces would be resurrected after a restart
+    - Screen sizes would be wrong after changing monitor configuration (#90)
+    - `spawnOnce` stopped working (xmonad/xmonad-contrib#155)
+    - Focus did not follow when moving between workspaces (#87)
+    - etc.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Remove the xmonad state file after reading it

Tries to make sure IO is not lazy so the file is processed before it is removed from the file system.

Fixes #86 and friends.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
