### PR TITLE
Safer string quoting for help message

### DIFF
--- a/src/XMonad/Config.hs
+++ b/src/XMonad/Config.hs
@@ -221,9 +221,9 @@ keys conf@(XConfig {XMonad.modMask = modMask}) = M.fromList $
     , ((modMask .|. shiftMask, xK_q     ), io (exitWith ExitSuccess)) -- %! Quit xmonad
     , ((modMask              , xK_q     ), spawn "if type xmonad; then xmonad --recompile && xmonad --restart; else xmessage xmonad not in \\$PATH: \"$PATH\"; fi") -- %! Restart xmonad
 
-    , ((modMask .|. shiftMask, xK_slash ), spawn ("echo \"" ++ help ++ "\" | xmessage -file -")) -- %! Run xmessage with a summary of the default keybindings (useful for beginners)
+    , ((modMask .|. shiftMask, xK_slash ), helpCommand)
     -- repeat the binding for non-American layout keyboards
-    , ((modMask              , xK_question), spawn ("echo \"" ++ help ++ "\" | xmessage -file -"))
+    , ((modMask              , xK_question), helpCommand)
     ]
     ++
     -- mod-[1..9] %! Switch to workspace N
@@ -237,6 +237,9 @@ keys conf@(XConfig {XMonad.modMask = modMask}) = M.fromList $
     [((m .|. modMask, key), screenWorkspace sc >>= flip whenJust (windows . f))
         | (key, sc) <- zip [xK_w, xK_e, xK_r] [0..]
         , (f, m) <- [(W.view, 0), (W.shift, shiftMask)]]
+  where
+    helpCommand :: String
+    helpCommand = spawn ("echo " ++ show help ++ " | xmessage -file -")  -- %! Run xmessage with a summary of the default keybindings (useful for beginners)
 
 -- | Mouse bindings: default actions bound to mouse events
 mouseBindings :: XConfig Layout -> M.Map (KeyMask, Button) (Window -> X ())


### PR DESCRIPTION
Using `show` to quote help string instead of hard-coding it.
Allows for quotes and other characters to be placed inside the help string.

### Description

Include a description for your changes, including the motivation
behind them.

> Ran into this after copying this code to add my own help message using [data-embed](https://hackage.haskell.org/package/data-embed) (You guys should consider embedding the help message aswell. Not sure if compile time file embedding is worth the price though (Extra dependency + TemplateHaskell).
> It took me a good few minutes to find the problem.

### Checklist

  - [ x ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ x ] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

> Not worth it, where clause might be indented wrong and not sure how documentation comments work in this situation but everything should be OK
> I just made this change from within the GitHub website.

  - [ ] I updated the `CHANGES.md` file

> Not worth it
