### PR TITLE
Safer string quoting for help message

### DIFF
--- a/src/XMonad/Config.hs
+++ b/src/XMonad/Config.hs
@@ -221,9 +221,9 @@ keys conf@(XConfig {XMonad.modMask = modMask}) = M.fromList $
     , ((modMask .|. shiftMask, xK_q     ), io (exitWith ExitSuccess)) -- %! Quit xmonad
     , ((modMask              , xK_q     ), spawn "if type xmonad; then xmonad --recompile && xmonad --restart; else xmessage xmonad not in \\$PATH: \"$PATH\"; fi") -- %! Restart xmonad
 
-    , ((modMask .|. shiftMask, xK_slash ), spawn ("echo \"" ++ help ++ "\" | xmessage -file -")) -- %! Run xmessage with a summary of the default keybindings (useful for beginners)
+    , ((modMask .|. shiftMask, xK_slash ), helpCommand)
     -- repeat the binding for non-American layout keyboards
-    , ((modMask              , xK_question), spawn ("echo \"" ++ help ++ "\" | xmessage -file -"))
+    , ((modMask              , xK_question), helpCommand)
     ]
     ++
     -- mod-[1..9] %! Switch to workspace N
@@ -237,6 +237,9 @@ keys conf@(XConfig {XMonad.modMask = modMask}) = M.fromList $
     [((m .|. modMask, key), screenWorkspace sc >>= flip whenJust (windows . f))
         | (key, sc) <- zip [xK_w, xK_e, xK_r] [0..]
         , (f, m) <- [(W.view, 0), (W.shift, shiftMask)]]
+  where
+    helpCommand :: X ()
+    helpCommand = spawn ("echo " ++ show help ++ " | xmessage -file -")  -- %! Run xmessage with a summary of the default keybindings (useful for beginners)
 
 -- | Mouse bindings: default actions bound to mouse events
 mouseBindings :: XConfig Layout -> M.Map (KeyMask, Button) (Window -> X ())


### PR DESCRIPTION
Using `show` to quote help string instead of hard-coding it.
Allows for quotes and other characters to be placed inside the help string.

See #110.