### PR TITLE
remove the man pages from data-files

### DIFF
--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -34,8 +34,6 @@ tested-with:
                     GHC==7.10.3,
                     GHC==8.0.1
 
-data-files:         man/xmonad.hs, man/xmonad.1, man/xmonad.1.html
-
 source-repository head
   type:     git
   location: https://github.com/xmonad/xmonad


### PR DESCRIPTION
The man pages are available for packagers in `extra-source-files`.

Having them in `data-files` is confusing since, according to Cabal's user guide [1], `data-files` contains "A list of files to be installed for run-time use by the package.", but the man pages are not used at run-time by xmonad.

[1]: https://www.haskell.org/cabal/users-guide/developing-packages.html

### Description

Include a description for your changes, including the motivation
behind them.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
