### PR TITLE
Remove unused CPP extension from Core.hs

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE ExistentialQuantification, FlexibleInstances, GeneralizedNewtypeDeriving,
-             MultiParamTypeClasses, TypeSynonymInstances, CPP, DeriveDataTypeable #-}
+             MultiParamTypeClasses, TypeSynonymInstances, DeriveDataTypeable #-}
 
 -----------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
### Description

Include a description for your changes, including the motivation
behind them.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
