### PR TITLE
Fix example config link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ to the last line of your `.xsession` or `.xinitrc` file.
 
 ## Configuring
 
-See the [CONFIG][] document and the [example configuration file][example-config].
+See the [CONFIG][] document and the [example configuration file](https://github.com/xmonad/xmonad-contrib/blob/master/XMonad/Config/Example.hs).
 
 ## XMonadContrib
 


### PR DESCRIPTION
### Description

The file in the pre-existing link just has a comment to this new location, so updating it in the README.md directly will save people a few mouse clicks

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
