### PR TITLE
Multipointer support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log / Release Notes
 
+## (Changes)
+### Bug Fixes
+	*When using two pointers (MPX) clicking on a window with the second, non-default pointer will set the keyboard focus on said window to the intended pointer and default. Now only the intended pointer focus is set.
+	*Focus follows mouse with second pointer
+
 ## 0.14 (Not Yet Released)
 
 ### Bug Fixes

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -367,10 +367,9 @@ handle e@(CrossingEvent {ev_window = w, ev_event_type = t})
     = whenX (asks $ focusFollowsMouse . config) $ do
         dpy <- asks display
         root <- asks theRoot
-        (_, _, w', _, _, _, _, _) <- io $ queryPointer dpy root
-        -- when Xlib cannot find a child that contains the pointer,
-        -- it returns None(0)
-        when (w' == 0 || w == w') (focus w)
+        --(_, _, w', _, _, _, _, _) <- io $ queryPointer dpy root
+        --when (w == w') (focus w)
+        focus w
 
 -- left a window, check if we need to focus root
 handle e@(CrossingEvent {ev_event_type = t})

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -367,8 +367,9 @@ handle e@(CrossingEvent {ev_window = w, ev_event_type = t})
     = whenX (asks $ focusFollowsMouse . config) $ do
         dpy <- asks display
         root <- asks theRoot
-        (_, _, w', _, _, _, _, _) <- io $ queryPointer dpy root
-        when (w == w') (focus w)
+        --(_, _, w', _, _, _, _, _) <- io $ queryPointer dpy root
+        --when (w == w') (focus w)
+        focus w
 
 -- left a window, check if we need to focus root
 handle e@(CrossingEvent {ev_event_type = t})

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -355,18 +355,7 @@ setFocusX w = withWindowSet $ \ws -> do
 
     when ((inputHintSet && wmh_input hints) || (not inputHintSet)) $
       io $ do setInputFocus dpy w revertToPointerRoot 0
-    when (wmtf `elem` protocols) $
-      io $ allocaXEvent $ \ev -> do
-        setEventType ev clientMessage
-        setClientMessageEvent ev w wmprot 32 wmtf $ maybe currentTime event_time currevt
-        sendEvent dpy w False noEventMask ev
-        where event_time ev =
-                if (ev_event_type ev) `elem` timedEvents then
-                  ev_time ev
-                else
-                  currentTime
-              timedEvents = [ keyPress, keyRelease, buttonPress, buttonRelease, enterNotify, leaveNotify, selectionRequest ]
-
+    
 ------------------------------------------------------------------------
 -- Message handling
 


### PR DESCRIPTION
### Description

I learned about [MPX](https://en.wikipedia.org/wiki/Multi-Pointer_X) and wrote a script to automate setting it up. I've been using it all summer in conjunction with XMonad, but there have been glitches with focus. The main issue has been trying to focus a window with the second pointer via clicking or XMonad functions. The default and the secondary pointer are now focused onto the window. I wanted all pointers to be independant of each other so that each focus/defocus does not affect other pointers.
After my changes, it is still not a perfect multi seat environment, but it is pretty close.
### Checklist

  - [x ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x ] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ x] I updated the `CHANGES.md` file
