### PR TITLE
Use precise in travisCI for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # This file has been generated -- see https://github.com/hvr/multi-ghc-travis
 language: c
 sudo: false
+dist: precise
 
 cache:
   directories:


### PR DESCRIPTION
This fixes the build for now. We should figure out why things don't work in trusty though.