### PR TITLE
restored compatability with GHC versions prior to 8.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
     the focus follows when the mouse enters another workspace
     but not moving into any window.
 
+  * Restored compatability with GHC version prior to 8.0.1 by removing the
+    dependency on directory version 1.2.3.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -57,6 +57,7 @@ import Data.Typeable
 import Data.List ((\\))
 import Data.Maybe (isJust,fromMaybe)
 import Data.Monoid
+import System.Environment (lookupEnv)
 
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -460,7 +461,7 @@ getXMonadDir :: MonadIO m => m String
 getXMonadDir =
     findFirstDirWithEnv "XMONAD_CONFIG_DIR"
       [ getAppUserDataDirectory "xmonad"
-      , getXdgDirectory XdgConfig "xmonad"
+      , getXDGDirectory XDGConfig "xmonad"
       ]
 
 -- | Return the path to the xmonad cache directory.  This directory is
@@ -480,7 +481,7 @@ getXMonadCacheDir :: MonadIO m => m String
 getXMonadCacheDir =
     findFirstDirWithEnv "XMONAD_CACHE_DIR"
       [ getAppUserDataDirectory "xmonad"
-      , getXdgDirectory XdgCache "xmonad"
+      , getXDGDirectory XDGCache "xmonad"
       ]
 
 -- | Return the path to the xmonad data directory.  This directory is
@@ -500,7 +501,7 @@ getXMonadDataDir :: MonadIO m => m String
 getXMonadDataDir =
     findFirstDirWithEnv "XMONAD_DATA_DIR"
       [ getAppUserDataDirectory "xmonad"
-      , getXdgDirectory XdgData "xmonad"
+      , getXDGDirectory XDGData "xmonad"
       ]
 
 -- | Helper function that will find the first existing directory and
@@ -536,6 +537,27 @@ findFirstDirWithEnv envName paths = do
       Nothing      -> findFirstDirOf paths
       Just envPath -> findFirstDirOf (return envPath:paths)
 
+-- | Helper function to retrieve the various XDG directories.
+-- This has been based on the implementation shipped with GHC version 8.0.1 or
+-- higher. Put here to preserve compatibility with older GHC versions.
+getXDGDirectory :: XDGDirectory -> FilePath -> IO FilePath
+getXDGDirectory xdgDir suffix =
+  normalise . (</> suffix) <$>
+  case xdgDir of
+    XDGData   -> get False "XDG_DATA_HOME"   ".local/share"
+    XDGConfig -> get False "XDG_CONFIG_HOME" ".config"
+    XDGCache  -> get True  "XDG_CACHE_HOME"  ".cache"
+  where
+    get _ name fallback = do
+      env <- lookupEnv name
+      case env of
+        Nothing -> fallback'
+        Just path
+          | isRelative path -> fallback'
+          | otherwise -> return path
+      where
+        fallback' = (</> fallback) <$> getHomeDirectory
+data XDGDirectory = XDGData | XDGConfig | XDGCache
 
 -- | Get the name of the file used to store the xmonad window state.
 stateFileName :: (Functor m, MonadIO m) => m FilePath

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -544,11 +544,11 @@ getXDGDirectory :: XDGDirectory -> FilePath -> IO FilePath
 getXDGDirectory xdgDir suffix =
   normalise . (</> suffix) <$>
   case xdgDir of
-    XDGData   -> get False "XDG_DATA_HOME"   ".local/share"
-    XDGConfig -> get False "XDG_CONFIG_HOME" ".config"
-    XDGCache  -> get True  "XDG_CACHE_HOME"  ".cache"
+    XDGData   -> get "XDG_DATA_HOME"   ".local/share"
+    XDGConfig -> get "XDG_CONFIG_HOME" ".config"
+    XDGCache  -> get "XDG_CACHE_HOME"  ".cache"
   where
-    get _ name fallback = do
+    get name fallback = do
       env <- lookupEnv name
       case env of
         Nothing -> fallback'

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -70,7 +70,7 @@ library
     build-depends: base < 5 && >=3,
                    containers,
                    data-default,
-                   directory >= 1.2.3,
+                   directory,
                    extensible-exceptions,
                    filepath,
                    setlocale,


### PR DESCRIPTION
### Description

A commit by @pjones broke compatability with older versions of GHC, fixed it by making our own `getXDGDirectory` implementation.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
