### PR TITLE
Fix typo Utils -> Util

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -73,7 +73,7 @@ data XState = XState
     , extensibleState  :: !(M.Map String (Either String StateExtension))
     -- ^ stores custom state information.
     --
-    -- The module "XMonad.Utils.ExtensibleState" in xmonad-contrib
+    -- The module "XMonad.Util.ExtensibleState" in xmonad-contrib
     -- provides additional information and a simple interface for using this.
     }
 


### PR DESCRIPTION
This is extremely minor, but it results in haddock incorrectly
hyperlinking XMonad.Utils.ExtensibleState at
https://hackage.haskell.org/package/xmonad-0.13/docs/XMonad-Core.html#v:extensibleState

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

I've foregone updating `CHANGES.md` as it's such a minor change.