### PR TITLE
Log information about xmonad compile + avoid unnecessary recompile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,18 @@
   * Restored compatability with GHC version prior to 8.0.1 by removing the
     dependency on directory version 1.2.3.
 
+  * xmonad no longer always recompile on startup. Now it only does so if the
+    executable does not have the name that would be used for the compilation
+    output. The purpose of recompiling and executing the results in this case is
+    so that the `xmonad` executable in the package can be used with custom
+    configurations.
+
+### Enhancements
+
+  * Whenever xmonad recompiles, it now explains how it is attempting to
+    recompile, by outputting logs to stderr. If you are using xmonad as a custom
+    X session, then this will end up in a `.xsession-errors` file.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -113,12 +113,18 @@ usage = do
 --
 buildLaunch ::  IO ()
 buildLaunch = do
-    recompile False
-    dir  <- getXMonadDataDir
-    args <- getArgs
     whoami <- getProgName
     let compiledConfig = "xmonad-"++arch++"-"++os
-    unless (whoami == compiledConfig) $
+    unless (whoami == compiledConfig) $ do
+      trace $ concat
+        [ "XMonad is recompiling and replacing itself another XMonad process because the current process is called "
+        , show whoami
+        , " but the compiled configuration should be called "
+        , show compiledConfig
+        ]
+      recompile False
+      dir  <- getXMonadDataDir
+      args <- getArgs
       executeFile (dir </> compiledConfig) False args Nothing
 
 sendRestart :: IO ()


### PR DESCRIPTION
### Description

Particularly with the addition of build scripts, it can be tricky to figure out
what XMonad is doing when attempting recompilation.  This makes it clearer by
adding some logging.

Due to this logging, I noticed that the lag of xmonad start was because it was
always recompiling!  When I startup my computer, I do not want it to delay
rebuilding my window manager. This also fixes that issue such that it only
recompiles XMonad if it is going to reinvoke due to getProgName not being the
expected string.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

      - [x] I have tested these changes with [my own xmonad configuration](https://github.com/mgsloan/dotfiles). Btw, is it possible that the above checklist item might reduce contribution?  How about making it optional?  I'd hope that xmonad-testing would be involved in some sort of CI, so contributors should not need to do that manually.

  - [x] I updated the `CHANGES.md` file
