### PR TITLE
Allow  X11-1.9

### DIFF
--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -80,7 +80,7 @@ library
                    process,
                    unix,
                    utf8-string >= 0.3 && < 1.1,
-                   X11>=1.8 && < 1.9,
+                   X11>=1.8 && < 1.10,
                    semigroups
 
     if true


### PR DESCRIPTION
Allow build with X11-1.9

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

tested in https://build.opensuse.org/project/show/devel:languages:haskell:lts:next/ and on openSUSE:Tumbleweed
