### PR TITLE
[WIP] prepare for GHC 8.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## unknown (unknown)
 
+### Bug Fixes
+
+  * Compiles with GHC 8.6.1
+
 ### Breaking Changes
 
   * The cabal build no longer installs xmonad.hs, xmonad.1, and xmonad.1.html

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -434,7 +434,7 @@ xfork x = io . forkProcess . finally nullStdin $ do
                 x
  where
     nullStdin = do
-        fd <- openFd "/dev/null" ReadOnly Nothing defaultFileFlags
+        fd <- openFd "/dev/null" ReadOnly defaultFileFlags
         dupTo fd stdInput
         closeFd fd
 

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -71,7 +71,7 @@ library
                    setlocale,
                    mtl,
                    process,
-                   unix,
+                   unix >= 2.8.0.0,
                    utf8-string >= 0.3 && < 1.1,
                    X11>=1.8 && < 1.10,
                    semigroups


### PR DESCRIPTION
### Description

Updated XMonad to use the latest version of the `unix` package, allowing it to work with GHC 8.6.1. This requires the `unix` package to be uploaded to hackage so it will not pass CI until then.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
