### PR TITLE
Update Debian packages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ We'll now walk through the complete list of toolchain dependencies.
     library headers. On many platforms, these come pre-installed. For
     others, such as Debian, you can get them from your package manager:
 
-        $ apt-get install libx11-dev libxinerama-dev libxext-dev libxrandr-dev
+        # for xmonad
+        $ apt-get install libx11-dev libxinerama-dev libxext-dev libxrandr-dev libxss-dev
+
+        # for xmonad-contrib
+        $ apt-get install libxft-dev
 
 Then build and install with:
 


### PR DESCRIPTION
### Description

I found that when I used Cabal to install xmonad 0.14 and xmonad-contrib 0.14 (according to the Quick Start section) on a minimal Debian 9.5 system I needed some Debian packages not mentioned in the README, so this PR adds references to those packages.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
