### PR TITLE
Fix typo in delete test comment: identiy -> identity

### DIFF
--- a/tests/Properties/Delete.hs
+++ b/tests/Properties/Delete.hs
@@ -18,7 +18,7 @@ prop_delete x =
     where _ = x :: T
 
 -- delete is reversible with 'insert'.
--- It is the identiy, except for the 'master', which is reset on insert and delete.
+-- It is the identity, except for the 'master', which is reset on insert and delete.
 --
 prop_delete_insert (x :: T) =
     case peek x of


### PR DESCRIPTION
### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
