### PR TITLE
Use current workspace to set dimensions of unmapped floating windows

### DIFF
--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -565,7 +565,10 @@ floatLocation w =
           ws <- gets windowset
           wa <- io $ getWindowAttributes d w
           let bw = (fromIntegral . wa_border_width) wa
-          sc <- fromMaybe (W.current ws) <$> pointScreen (fi $ wa_x wa) (fi $ wa_y wa)
+          managed <- isClient w
+          sc <- if managed
+                then fromMaybe (W.current ws) <$> pointScreen (fi $ wa_x wa) (fi $ wa_y wa)
+                else return (W.current ws)
 
           let sr = screenRect . W.screenDetail $ sc
               rr = W.RationalRect ((fi (wa_x wa) - fi (rect_x sr)) % fi (rect_width sr))


### PR DESCRIPTION
This fixes a bug when using multiple screens with different dimensions, causing floating windows to always increase in size or always decrease in size every time they're opened.

In such a situation, a floating window is first mapped at (0,0) (on the leftmost screen), using the dimensions of that screen, before being inserted in the current workspace, which may be on another screen, causing the window to be resized if that screen has larger or smaller dimensions. If the window then saves its size in pixels when closed, the next time it opens, it will go through this process again, causing it to become even larger or smaller.

This commit fixes this by using the current workspace to calculate dimensions for unmapped floating windows, instead of the workspace at screen position (0,0).

---

However, the same kind of problem remains if, for example, a custom ManageHook is used to automatically move a floating window to a workspace on a screen with different dimensions than the current workspace. I'm not sure what the proper fix should be for that, short of rewriting the entire floating layer to use pixel dimensions instead of "percent-of-screen-size" dimensions.

---

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file