### PR TITLE
Update example config link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ For a program dispatch menu:
 [xmonadcontrib]: https://hackage.haskell.org/package/xmonad-contrib
 [xmc-prompt-shell]: https://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Prompt-Shell.html
 [platform]: http://haskell.org/platform/
-[example-config]: https://github.com/xmonad/xmonad-testing/blob/master/example-config.hs
+[example-config]: https://github.com/xmonad/xmonad-contrib/blob/master/XMonad/Config/Example.hs
 [config]: https://github.com/xmonad/xmonad/blob/master/CONFIG


### PR DESCRIPTION
The link for the example config leads to file saying "go here instead"; change initial link to "there".

### Description

Well, save a few clicks whenever you go looking for an example config because you forgot how configs work (speaking from experience).

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

    > It's a tiny change to the README, could it break stuff?

  - [ ] I updated the `CHANGES.md` file

    > Not yet.