### PR TITLE
Make "Default Keyboard Bindings" a heading

### DIFF
--- a/man/xmonad.1.markdown
+++ b/man/xmonad.1.markdown
@@ -72,7 +72,7 @@ These flags are:
 --verbose-version
 :   Display detailed version of _xmonad_
 
-##Default keyboard bindings
+## Default keyboard bindings
 
 ___KEYBINDINGS___
 


### PR DESCRIPTION
It looks like it should be a heading, but there wasn't a space so it wasn't one. Looked strange in the manpage.

### Description

Spotted an oddity in the manpage. I'm guessing this was meant to be a heading in the original Markdown document, but a space was forgotten. This pull inserts said space.

![image](https://user-images.githubusercontent.com/7798336/71134999-e7d52180-21c5-11ea-874d-b4bf8017d827.png)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

I'm going to add this to the checklist as it seems relevant:

- [ ] Rebuild man/docs

It would probably take me a few days to be able to do this (still setting things up after hd went corrupt). If someone else could take of that, it would be awesome.
