### PR TITLE
Add Nix build support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log / Release Notes
 
+## 0.15.1 (March 22, 2020)
+
+  * Added Nix build support
+
 ## unknown (unknown)
 
 ## 0.15 (September 30, 2018)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, base, containers, data-default, directory
+, extensible-exceptions, filepath, mtl, process, QuickCheck
+, setlocale, stdenv, unix, utf8-string, X11
+}:
+mkDerivation {
+  pname = "xmonad";
+  version = "0.15";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base containers data-default directory extensible-exceptions
+    filepath mtl process setlocale unix utf8-string X11
+  ];
+  executableHaskellDepends = [ base mtl unix X11 ];
+  testHaskellDepends = [
+    base containers extensible-exceptions QuickCheck X11
+  ];
+  postInstall = ''
+    install -D man/xmonad.1 ''${!outputDoc}/share/man/man1/xmonad.1
+    install -D man/xmonad.hs ''${!outputDoc}/share/doc/$name/sample-xmonad.hs
+  '';
+  homepage = "http://xmonad.org";
+  description = "A tiling window manager";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,0 +1,9 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs.git",
+  "rev": "9b3515eb95d9b3bc033f43cd562fe2b14f9efd86",
+  "date": "2020-03-19T11:24:57+01:00",
+  "sha256": "1gc1hc30cqymkrrw4nj545md6h5dr9cpjf10vh080wwf5ybaggcl",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,26 @@
+let
+  config = {
+    packageOverrides = pkgs: rec {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: rec {
+          app =
+            haskellPackagesNew.callPackage ./default.nix { };
+        };
+      };
+    };
+  };
+
+  bootstrap = import <nixpkgs> { };
+
+  nixpkgs = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+
+  src = bootstrap.fetchFromGitHub {
+    owner = "NixOS";
+    repo  = "nixpkgs";
+    inherit (nixpkgs) rev sha256;
+  };
+
+  pkgs = import src { inherit config; };
+
+in
+  { app = pkgs.haskellPackages.app; pkgs = pkgs;}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+let
+    project = import ./release.nix;
+    pkgs = project.pkgs;
+
+    inherit (pkgs) haskellPackages;
+in
+    pkgs.stdenv.mkDerivation {
+      name = "shell";
+      buildInputs = project.app.env.nativeBuildInputs ++ [
+        haskellPackages.cabal-install
+      ];
+    }


### PR DESCRIPTION
### Description

Project can now be built with ``nix-build release.nix`` and installed with ``nix-env --install ./result``

X dependencies are packaged so there is no need to manually install them.

Also removes the need to install/update Cabal leading to a potentially easier install experience.

> Note: [Xmobar does something similar
](https://github.com/jaor/xmobar/blob/master/default.nix)
### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
