### PR TITLE
Use current screen to set dimensions of new floating windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## unknown (unknown)
 
+  * Fixed a bug when using multiple screens with different dimensions,
+    causing some floating windows to be smaller/larger than the size they
+    requested.
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made


### PR DESCRIPTION
### Description

This fixes a bug when using multiple screens with different dimensions,
causing some floating windows to be smaller/larger than the size they
requested.

Some applications (e.g. pinentry) always map their window at (0, 0) so
floatLocation would compute the window size relative to the screen
containing (0, 0) and if the current workspace is on another screen with
a different size, this relative size results in a different absolute
size, which is undesirable for fixed size floats.

Other applications like ssh-agent place their window at the center of
the framebuffer (ignoring xinerama layout). Same problem.

Then there are apps that remember their position/size when minimizing to
tray and then attempt to restore it when reopened. Again, if they
restore it on another screen, we miscalculate the size.

The fix is to use the current screen for calculating dimensions of new
(not yet mapped) floating windows.

Co-Authored-By: @Narthorn (https://github.com/xmonad/xmonad/pull/197)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file