### PR TITLE
Make layouts Typeable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
     causing some floating windows to be smaller/larger than the size they
     requested.
 
+  * Added `Typeable layout` constraint to `LayoutClass`, making it possible to
+    cast `Layout` back into a concrete type and extract current layout state
+    from it.
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -271,7 +271,7 @@ readsLayout (Layout l) s = [(Layout (asTypeOf x l), rs) | (x, rs) <- reads s]
 -- 'runLayout', 'handleMessage', and so on.  This ensures that the
 -- proper methods will be used, regardless of the particular methods
 -- that any 'LayoutClass' instance chooses to define.
-class Show (layout a) => LayoutClass layout a where
+class (Show (layout a), Typeable layout) => LayoutClass layout a where
 
     -- | By default, 'runLayout' calls 'doLayout' if there are any
     --   windows to be laid out, and 'emptyLayout' otherwise.  Most


### PR DESCRIPTION
### Description

This makes it possible to query the current layout state, which might be
useful to e.g. show the current X.L.WorkspaceDir in xmobar.

Example of use (assuming myLayout is the layout that is assigned to
layoutHook):

    asMyLayout (Layout l) = (`asTypeOf` myLayout) <$> cast l

    …

    layout <- asMyLayout . W.layout . W.workspace . W.current <$> gets windowset
    case layout of
        Just (WorkspaceDir d) -> …

Full example: https://github.com/liskin/dotfiles/commit/6ea6c52aac4d39fa5a788372e005954715cb6d9a

Unfortunately this requires adding the Typeable constraint to a bunch of
classes in xmonad-contrib, so we need to merge those changes there first
(fortunately it doesn't need to go in lockstep, adding a Typeable
constraint to those classes in xmonad-contrib is harmless):
https://github.com/xmonad/xmonad-contrib/pull/398

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
