### PR TITLE
Add required + before flag name cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -4,4 +4,4 @@ packages:
   xmonad.cabal
 
 package xmonad
-  flags: generatemanpage
+  flags: +generatemanpage


### PR DESCRIPTION
### Description

This fixes the build with cabal-3.4.

### Checklist

  - [*] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [*] I've confirmed these changes don't belong in xmonad-contrib instead

  - [*] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [n/a] I updated the `CHANGES.md` file
