### PR TITLE
Fix dzen URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For custom status bars:
 
   * taffybar: <https://github.com/travitch/taffybar>
 
-  * dzen: <http://gotmor.googlepages.com/dzen>
+  * dzen: <https://github.com/robm/dzen>
 
 For a program dispatch menu:
 


### PR DESCRIPTION
dzen has moved to GitHub

### Description

> Dzen moved to github this page and the wiki are as well subject to move in the next couple of weeks.

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
