### PR TITLE
Get rid of unused imports

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -36,7 +36,6 @@ import XMonad.StackSet hiding (modify)
 import Prelude
 import Control.Exception.Extensible (fromException, try, bracket, throw, finally, SomeException(..))
 import qualified Control.Exception.Extensible as E
-import Control.Applicative(Applicative, pure, (<$>), (<*>))
 import Control.Monad.Fail
 import Control.Monad.State
 import Control.Monad.Reader
@@ -58,7 +57,6 @@ import Graphics.X11.Xlib.Extras (getWindowAttributes, WindowAttributes, Event)
 import Data.Typeable
 import Data.List ((\\))
 import Data.Maybe (isJust,fromMaybe)
-import Data.Monoid hiding ((<>))
 import System.Environment (lookupEnv)
 
 import qualified Data.Map as M

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -29,9 +29,7 @@ import Data.Ratio
 import qualified Data.Map as M
 import qualified Data.Set as S
 
-import Control.Applicative((<$>), (<*>))
 import Control.Arrow (second)
-import Control.Monad (void)
 import Control.Monad.Reader
 import Control.Monad.State
 import qualified Control.Exception.Extensible as C

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -84,7 +84,11 @@ library
                  , setlocale
                  , unix
                  , utf8-string           >= 0.3 && < 1.1
-  ghc-options:     -funbox-strict-fields -Wall -fno-warn-unused-do-bind
+  ghc-options:     -funbox-strict-fields -Wall -fno-warn-unused-do-bind -Wno-unused-imports
+
+  -- Keep this in sync with the oldest version in 'tested-with'
+  if impl(ghc <= 8.4.4)
+     ghc-options: -Werror=unused-imports
 
   if flag(testing)
     buildable: False
@@ -92,7 +96,11 @@ library
 executable xmonad
   main-is:       Main.hs
   build-depends: base, X11, mtl, unix, xmonad
-  ghc-options:   -Wall -fno-warn-unused-do-bind
+  ghc-options:   -Wall -fno-warn-unused-do-bind -Wno-unused-imports
+
+  -- Keep this in sync with the oldest version in 'tested-with'
+  if impl(ghc <= 8.4.4)
+     ghc-options: -Werror=unused-imports
 
 executable generatemanpage
   main-is:        GenerateManpage.hs

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -27,8 +27,7 @@ author:             Spencer Janssen, Don Stewart, Adam Vogt, David Roundy, Jason
                     Ondřej Súkup, Paul Hebble, Shachaf Ben-Kiki, Siim Põder, Tim McIver,
                     Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion
 maintainer:         xmonad@haskell.org
-tested-with:        GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3, GHC == 8.6.5,
-                    GHC == 8.8.4, GHC == 8.10.2
+tested-with:        GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.8.4
 category:           System
 homepage:           http://xmonad.org
 bug-reports:        https://github.com/xmonad/xmonad/issues


### PR DESCRIPTION
### Description

Starting with  28e75da77fa1918ec3ef4ce63ada32507a75b50c we only support GHC versions 8.4.3 and up (more precisely, the GHC version associated with stackage lts-12.0 and up).  This is a good time to get rid of all the imports that are now actually unused for all supported versions.

This pr produces no unused import warnings up to GHC 8.6.x and one unused import warning for GHC 8.8.x (this is due to MFP being implemented in 8.8.x)

I already have an equivalent pr ready for `xmonad-contrib`.  However, it seems like [the resolver there](https://github.com/xmonad/xmonad-contrib/blob/master/.github/workflows/tests.yml#L17) only starts at `lts-14.0` instead of `lts-12.0`, which probably needs to be fixed first.  cc @psibi   

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
