### PR TITLE
Rename LR = L | R to CLR = CL | CR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
     cast `Layout` back into a concrete type and extract current layout state
     from it.
 
-  * Export constructor for `Choose` and `LR` from `Module.Layout` to allow
+  * Export constructor for `Choose` and `CLR` from `Module.Layout` to allow
     pattern-matching on the left and right sub-layouts of `Choose l r a`.
 
 ## 0.15 (September 30, 2018)


### PR DESCRIPTION
### Description

Closes #250

Some modules in xmonad-contrib define their own LR type with L and R as data constructors, leading to build failures; this fixes that.  

The idea behind the name is that we're [c]hoosing whether we wan the [l]eft or [r]ight layout.  It's not perfect, but given that othe variances are either already taken (`Left`/`Right`) or too long (`ChooseL/R`), it may not be that bad.
 
### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
