### PR TITLE
Accord with new pattern-match

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
   * Export constructor for `Choose` and `CLR` from `Module.Layout` to allow
     pattern-matching on the left and right sub-layouts of `Choose l r a`.
 
+  * Compatibility with GHC 9.0
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -61,7 +61,7 @@ xmonad conf = do
 
     let launch' args = do
               catchIO buildLaunch
-              conf' @ XConfig { layoutHook = Layout l }
+              conf'@XConfig { layoutHook = Layout l }
                   <- handleExtraArgs conf args conf{ layoutHook = Layout (layoutHook conf) }
               withArgs [] $ launch (conf' { layoutHook = l })
 


### PR DESCRIPTION
### Description

Changes the syntax on one line. Otherwise GHC 9.0 will fail to parse it.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
