### PR TITLE
stack.yaml: switch from Stackage LTS to Nightly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        resolver: [lts-16, lts-15, lts-14, lts-12]
+        resolver: [nightly]
 
     steps:
       - name: Clone project

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,24 @@
-resolver: lts-16.22
+resolver: nightly-2021-01-05
+
+flags:
+  xmonad:
+    generatemanpage: true
 
 packages:
 - ./
 
 extra-deps:
 - X11-1.9.2
+- pandoc-2.11.3.2
+- citeproc-0.3.0.3
+- commonmark-0.1.1.2
+- commonmark-extensions-0.2.0.4
+- commonmark-pandoc-0.2.0.1
+
+nix:
+  packages:
+    - zlib
+    - xorg.libX11
+    - xorg.libXrandr
+    - xorg.libXScrnSaver
+    - xorg.libXext


### PR DESCRIPTION
Let's use a moderately recent compiler like ghc-8.10.3
instead of the old 8.8.x branch for development. Same goes
for our dependencies; development should take place with
recent versions of our dependencies.

This PR also fixes the build of `generatemanpage` and enables
it in our CI environment.