### PR TITLE
Control.Exception.Extensible -> Control.Exception

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -35,8 +35,8 @@ module XMonad.Core (
 import XMonad.StackSet hiding (modify)
 
 import Prelude
-import Control.Exception.Extensible (fromException, try, bracket, throw, finally, SomeException(..))
-import qualified Control.Exception.Extensible as E
+import Control.Exception (fromException, try, bracket, throw, finally, SomeException(..))
+import qualified Control.Exception as E
 import Control.Applicative ((<|>), empty)
 import Control.Monad.Fail
 import Control.Monad.State

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -16,7 +16,7 @@
 module XMonad.Main (xmonad, launch) where
 
 import System.Locale.SetLocale
-import qualified Control.Exception.Extensible as E
+import qualified Control.Exception as E
 import Data.Bits
 import Data.List ((\\))
 import Data.Function

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -21,8 +21,8 @@ module XMonad.ManageHook where
 import XMonad.Core
 import Graphics.X11.Xlib.Extras
 import Graphics.X11.Xlib (Display, Window, internAtom, wM_NAME)
-import Control.Exception.Extensible (bracket, SomeException(..))
-import qualified Control.Exception.Extensible as E
+import Control.Exception (bracket, SomeException(..))
+import qualified Control.Exception as E
 import Control.Monad.Reader
 import Data.Maybe
 import Data.Monoid

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -32,7 +32,7 @@ import qualified Data.Set as S
 import Control.Arrow (second)
 import Control.Monad.Reader
 import Control.Monad.State
-import qualified Control.Exception.Extensible as C
+import qualified Control.Exception as C
 
 import System.IO
 import System.Directory

--- a/tests/Properties/Failure.hs
+++ b/tests/Properties/Failure.hs
@@ -2,7 +2,7 @@ module Properties.Failure where
 
 import XMonad.StackSet hiding (filter)
 
-import qualified Control.Exception.Extensible as C
+import qualified Control.Exception as C
 import System.IO.Unsafe
 import Data.List (isPrefixOf)
 

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -77,7 +77,6 @@ library
                  , containers
                  , data-default
                  , directory
-                 , extensible-exceptions
                  , filepath
                  , mtl
                  , process
@@ -132,4 +131,4 @@ test-suite properties
                   Properties.Workspace
                   Utils
   hs-source-dirs: tests
-  build-depends:  base, QuickCheck >= 2, X11, containers, extensible-exceptions, xmonad
+  build-depends:  base, QuickCheck >= 2, X11, containers, xmonad


### PR DESCRIPTION
### Description

According to its documentation[1], this module simply re-exports
Control.Exception on recent GHC versions.  As we only support recent
versions, this import is unnecessary.

[1] http://hackage.haskell.org/package/extensible-exceptions-0.1.1.4/docs/Control-Exception-Extensible.html

This should probably be merged on conjunction with xmonad/xmonad-contrib/pull/444

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~
  Not needed as we've already dropped support for GHC versions that old.
