### PR TITLE
Revert "Re-enable lts based testing"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        resolver: [lts-16, lts-15, lts-14, lts-12]
+        resolver: [nightly]
 
     steps:
       - name: Clone project

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,19 @@
-resolver: lts-16.22
+resolver: nightly-2021-01-05
+
+flags:
+  xmonad:
+    generatemanpage: true
 
 packages:
 - ./
 
 extra-deps:
 - X11-1.9.2
+- pandoc-2.11.3.2
+- citeproc-0.3.0.3
+- commonmark-0.1.1.2
+- commonmark-extensions-0.2.0.4
+- commonmark-pandoc-0.2.0.1
 
 nix:
   packages:


### PR DESCRIPTION
Reverts xmonad/xmonad#266. This patch loses the ability to build `generatemanpage`.