### PR TITLE
Call xrrUpdateConfiguration to sync Xlib's view of screen config

### DIFF
--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -24,7 +24,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Control.Monad.Reader
 import Control.Monad.State
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Monoid (getAll)
 
 import Graphics.X11.Xlib hiding (refreshKeyboardMapping)
@@ -48,6 +48,7 @@ import Paths_xmonad (version)
 import Data.Version (showVersion)
 
 import Graphics.X11.Xinerama (compiledWithXinerama)
+import Graphics.X11.Xrandr (xrrQueryExtension, xrrUpdateConfiguration)
 
 ------------------------------------------------------------------------
 
@@ -261,8 +262,11 @@ launch initxmc drs = do
 
             userCode $ startupHook initxmc
 
+            rrData <- io $ xrrQueryExtension dpy
+            let rrUpdate = when (isJust rrData) . void . xrrUpdateConfiguration
+
             -- main loop, for all you HOF/recursion fans out there.
-            forever $ prehandle =<< io (nextEvent dpy e >> getEvent e)
+            forever $ prehandle =<< io (nextEvent dpy e >> rrUpdate e >> getEvent e)
 
     return ()
       where


### PR DESCRIPTION
### Description

Xrandrint.h says:

    /*
     * if a configure notify on the root is recieved, or
     * an XRRScreenChangeNotify is recieved,
     * XRRUpdateConfiguration should be called to update the X library's
     * view of the screen configuration; it will also invalidate the cache
     * provided by XRRScreenConfig and XRRConfig, and force a round trip
     * when next used.  Returns invalid status if not an event type
     * the library routine understand.
     */

If any user code needs that info/cache to be correct, we need to call
this.

---

This depends on https://github.com/xmonad/X11/pull/72


### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - n/a I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file