### PR TITLE
Pass 0 to setClientMessageEvent where appropriate

### DIFF
--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -133,7 +133,7 @@ sendRestart = do
     xmonad_restart <- internAtom dpy "XMONAD_RESTART" False
     allocaXEvent $ \e -> do
         setEventType e clientMessage
-        setClientMessageEvent e rw xmonad_restart 32 0 currentTime
+        setClientMessageEvent' e rw xmonad_restart 32 []
         sendEvent dpy rw False structureNotifyMask e
     sync dpy False
 

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -91,7 +91,7 @@ killWindow w = withDisplay $ \d -> do
     io $ if wmdelt `elem` protocols
         then allocaXEvent $ \ev -> do
                 setEventType ev clientMessage
-                setClientMessageEvent ev w wmprot 32 wmdelt 0
+                setClientMessageEvent ev w wmprot 32 wmdelt currentTime
                 sendEvent d w False noEventMask ev
         else killClient d w >> return ()
 


### PR DESCRIPTION
### Description

Stop pretending it has anything to do with time, it's zero, and it's not
being read anywhere, we're passing the parameter only because
setClientMessageEvent needs one. We should switch to
setClientMessageEvent' and pass no data, but that would move the X11
dependency lower bound.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - n/a I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - n/a I updated the `CHANGES.md` file