### PR TITLE
Fix obscuring notifications when moving floats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,9 @@
   * Change `ScreenDetail` to a newtype and make `RationalRect` strict in
     its contents.
 
+  * Fixed dunst notifications being obscured when moving floats.
+    https://github.com/xmonad/xmonad/issues/208
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -637,7 +637,6 @@ mouseDrag f done = do
 -- | drag the window under the cursor with the mouse while it is dragged
 mouseMoveWindow :: Window -> X ()
 mouseMoveWindow w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     (_, _, _, ox', oy', _, _, _) <- io $ queryPointer d w
     let ox = fromIntegral ox'
@@ -652,7 +651,6 @@ mouseMoveWindow w = whenX (isClient w) $ withDisplay $ \d -> do
 -- | resize the window under the cursor with the mouse while it is dragged
 mouseResizeWindow :: Window -> X ()
 mouseResizeWindow w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     sh <- io $ getWMNormalHints d w
     io $ warpPointer d none w 0 0 0 0 (fromIntegral (wa_width wa)) (fromIntegral (wa_height wa))


### PR DESCRIPTION
### Description

Since 4565e2c90ef5, not only do we raise the floating window to top when
starting dragging, we also restack all other managed windows directly
below it (mouse{Move,Resize}Window now call `float` while dragging,
which invoke `windows` and that restacks all windows). This means that
as soon as we start dragging, all xmonad-managed windows are raised to
the top, obscuring any unmanaged (override-redirect) windows that were
at the top before.

The good thing about 4565e2c90ef5 is that since we refloat and refresh
on every mouse move while dragging, we no longer need the `raiseWindow`.
It was probably only there so that it stays visible when dragging
between Xinerama screens (3cb64d74617), and that's taken care of by
refloating the window on every move. As the refresh restacks everything
anyway, the only function of the `raiseWindow` is to stack windows above
unmanaged ones, which is likely undesirable.

There is still one known issue related to obscuring notifications:
https://github.com/xmonad/xmonad/issues/89
That one is caused by X opening new windows at the top of stacking order
and xmonad then restacking all other windows directly beneath them if
the new window is in the master position of the stack. Some notification
daemons like dunst work around this by raising themselves whenever a new
window is opened
(https://github.com/dunst-project/dunst/blob/77bfbc4f7ff0a0ace6a7c9f0d9823ca3ca0fe3fd/src/x11/x.c#L348).
Fixing this one is considerably more complicated as we'd need to keep
track of (unmanaged) windows that wish to be stacked above new windows,
therefore this won't be addressed here, and probably won't be addressed
in xmonad core ever.

Fixes: https://github.com/xmonad/xmonad/issues/208
Fixes: 4565e2c90ef5 ("fix #63: window jumping to origin position when dragging")

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - n/a I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file