### PR TITLE
Merge X.L.LayoutCombinators.(|||) into X.L.(|||)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@
   * Added the `extensibleConf` field to `XConfig` which makes it easier for
     contrib modules to have composable configuration (custom hooks, …).
 
+  * Migrated `X.L.LayoutCombinators.(|||)` into `XMonad.Layout`,
+    providing the ability to directly jump to a layout with the
+    `JumpToLayout` message.
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made


### PR DESCRIPTION
### Description

The functionality of the forme are quite handy to have in core and we
can do so with minimal code changes.

The drawbacks of this approach are

  1. We can't merge `JumpToLayout` into `ChangeLayout` because people may
     have imported `JumpToLayout(..)`, which we can't simulate with type
     aliases

  2. Because the internal structure of `X.L.LayoutCombintors.(|||)` is a
     bit different, this creates a regression for people who used
     `NextLayoutNoWrap` or `Wrap` in their configs.  We could work around
     this by creating fake instances of these fields in the new
     `JumpToLayout` constructor and simply not doing anything with them,
     but since this seems like quite an advanced and specific use-case,
     failing fast and hard (as opposed to adding deprecation messages
     and then "silently" not handling these messages) seems preferrable
     here.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
