### PR TITLE
Broadcast `DestroyWindowEvent` to layouts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,9 @@
 
   * Document the help command in the help message.
 
+  * `DestroyWindowEvent` is now broadcasted to layouts to let them know
+    window-specific resources can be discarded.
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made

--- a/src/XMonad/Layout.hs
+++ b/src/XMonad/Layout.hs
@@ -27,6 +27,7 @@ module XMonad.Layout (
 import XMonad.Core
 
 import Graphics.X11 (Rectangle(..))
+import Graphics.X11.Xlib.Extras ( Event(DestroyWindowEvent) )
 import qualified XMonad.StackSet as W
 import Control.Arrow ((***), second)
 import Control.Monad
@@ -229,6 +230,9 @@ instance (LayoutClass l a, LayoutClass r a) => LayoutClass (Choose l r) a where
 
     handleMessage c@(Choose d l r) m | Just ReleaseResources <- fromMessage m =
         join $ liftM2 (choose c d) (handle l ReleaseResources) (handle r ReleaseResources)
+
+    handleMessage c@(Choose d l r) m | Just e@DestroyWindowEvent{} <- fromMessage m =
+        join $ liftM2 (choose c d) (handle l e) (handle r e)
 
     handleMessage c@(Choose d l r) m | Just (JumpToLayout desc) <- fromMessage m = do
         ml <- handleMessage l m


### PR DESCRIPTION
### Description

Some layout and layout modifiers that keep track of some window
properties don't do garbage collection and update their state when
windows are destroyed. By broadcasting this event, it should be easier
for layouts to clean up

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
