### PR TITLE
Add `MINIMAL` for `ExtensionClass` and `LayoutClass`

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -387,6 +387,7 @@ instance Message LayoutMessages
 --
 -- Minimal complete definition: initialValue
 class Typeable a => ExtensionClass a where
+    {-# MINIMAL initialValue #-}
     -- | Defines an initial value for the state extension
     initialValue :: a
     -- | Specifies whether the state extension should be

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -256,14 +256,18 @@ readsLayout (Layout l) s = [(Layout (asTypeOf x l), rs) | (x, rs) <- reads s]
 -- | Every layout must be an instance of 'LayoutClass', which defines
 -- the basic layout operations along with a sensible default for each.
 --
--- Minimal complete definition:
+-- All of the methods have default implementations, so there is no
+-- minimal complete definition.  They do, however, have a dependency
+-- structure by default; this is something to be aware of should you
+-- choose to implement one of these methods.  Here is how a minimal
+-- complete definition would look like if we did not provide any default
+-- implementations:
 --
--- * 'runLayout' || (('doLayout' || 'pureLayout') && 'emptyLayout'), and
+-- * 'runLayout' || (('doLayout' || 'pureLayout') && 'emptyLayout')
 --
 -- * 'handleMessage' || 'pureMessage'
 --
--- You should also strongly consider implementing 'description',
--- although it is not required.
+-- * 'description'
 --
 -- Note that any code which /uses/ 'LayoutClass' methods should only
 -- ever call 'runLayout', 'handleMessage', and 'description'!  In


### PR DESCRIPTION
### Description

Add a `MINIMAL` pragma for the type classes that should really have had one in the first place (i.e. the ones that currently have some kind of "minimal complete definition" in their docstring).  Since we now only support GHC versions that support that kind of pragma, it seems like the right thing to do.  I left the comments in for now, but I suppose an argument could be made that they should be removed, since Haddock will correctly generate a `Minimal complete definition` heading.

I also added the relevant definitions for `Full` and `Tall`, so there's no scary warnings generated.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~
