### PR TITLE
Add Sponsor button to GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github:
+  - liskin


### PR DESCRIPTION
### Description

These past months I've spent a lot of time working on xmonad¹ and I feel like I've done a lot. This is, however, not sustainable long term. :-(

¹) primarily xmonad-contrib and the community in general

I'd like to try making my GitHub Sponsors profile a bit more visible, hoping that would allow me to continue dedicating time to xmonad.

I know that the correct approach probably is for the xmonad project to find a fiscal sponsor like the Software Freedom Conservancy or Open Collective or something and accept donations as a project, and then redistribute that to people, but I don't think the project has enough momentum to do something as complicated as that. :-/

Related: https://github.com/xmonad/xmonad-contrib/pull/544

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

    They do belong to both.

  - n/a I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - n/a I updated the `CHANGES.md` file