### PR TITLE
Prevent grabKey from accidentally grabbing all unbound keys

### DIFF
--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -473,8 +473,11 @@ grabKeys = do
     -- build a map from keysyms to lists of keysyms (doing what
     -- XGetKeyboardMapping would do if the X11 package bound it)
     syms <- forM allCodes $ \code -> io (keycodeToKeysym dpy code 0)
-    let keysymMap = M.fromListWith (++) (zip syms [[code] | code <- allCodes])
-        keysymToKeycodes sym = M.findWithDefault [] sym keysymMap
+    let keysymMap' = M.fromListWith (++) (zip syms [[code] | code <- allCodes])
+    -- keycodeToKeysym returns noSymbol for all unbound keycodes, and we don't
+    -- want to grab those whenever someone accidentally uses def :: KeySym
+    let keysymMap = M.delete noSymbol keysymMap'
+    let keysymToKeycodes sym = M.findWithDefault [] sym keysymMap
     forM_ (M.keys ks) $ \(mask,sym) ->
          forM_ (keysymToKeycodes sym) $ \kc ->
               mapM_ (grab kc . (mask .|.)) =<< extraModifiers


### PR DESCRIPTION
### Description

grabKeys doesn't check that a KeySym is valid before looking up the KeyCode(s) it's bound to. In particular, KeySym 0 (NoSymbol) gets mapped to every unbound KeyCode, since that's what XKeycodeToKeysym returns for those.

This can most easily be reproduced using `statusBar` in xmonad-contrib, with def as the key-mapping function; this unexpectedly invokes the following instances:

    instance Default b => a -> b where def = const def
    instance (Default a, Default b) => (a, b) where def = (def, def)
    instance Default CInt where def = 0

thus producing a function which binds `toggleStruts` to the (KeyMask, KeySym) pair (0, 0) (and demonstrating why Default is a dangerous abstraction). Note that it is not reliably possible to override `def` in this situation; the only thing we can do is try to avoid the aftermath, and I would expect that an inadvertent 0 KeySym is the most common error here anyway.

Fixes: https://github.com/xmonad/xmonad/issues/293
Fixes: 40cb12ce174a ("Grab all keycodes linked to each keysym, not just one")
Co-authored-by: @geekosaur

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

    Tested locally using `io $ print keysymMap`

  - [ ] I updated the `CHANGES.md` file

    I believe this is so minor that it's just noise to most people.