### PR TITLE
Remove all instances of deriving Typeable

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -154,7 +154,7 @@ newtype ScreenDetail = SD { screenRect :: Rectangle }
 -- instantiated on 'XConf' and 'XState' automatically.
 --
 newtype X a = X (ReaderT XConf (StateT XState IO) a)
-    deriving (Functor, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf, Typeable)
+    deriving (Functor, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf)
 
 instance Applicative X where
   pure = return
@@ -383,7 +383,7 @@ instance Message Event
 -- layouts) should consider handling.
 data LayoutMessages = Hide              -- ^ sent when a layout becomes non-visible
                     | ReleaseResources  -- ^ sent when xmonad is exiting or restarting
-    deriving (Typeable, Eq)
+    deriving Eq
 
 instance Message LayoutMessages
 

--- a/src/XMonad/Layout.hs
+++ b/src/XMonad/Layout.hs
@@ -8,7 +8,7 @@
 --
 -- Maintainer  :  spencerjanssen@gmail.com
 -- Stability   :  unstable
--- Portability :  not portable, Typeable deriving, mtl, posix
+-- Portability :  not portable, mtl, posix
 --
 -- The collection of core layouts.
 --
@@ -35,10 +35,10 @@ import Data.Maybe (fromMaybe)
 ------------------------------------------------------------------------
 
 -- | Change the size of the master pane.
-data Resize     = Shrink | Expand   deriving Typeable
+data Resize     = Shrink | Expand
 
 -- | Increase the number of clients in the master pane.
-data IncMasterN = IncMasterN !Int    deriving Typeable
+data IncMasterN = IncMasterN !Int
 
 instance Message Resize
 instance Message IncMasterN
@@ -132,7 +132,7 @@ mirrorRect (Rectangle rx ry rw rh) = Rectangle ry rx rh rw
 -- Layouts that transition between other layouts
 
 -- | Messages to change the current layout.
-data ChangeLayout = FirstLayout | NextLayout deriving (Eq, Show, Typeable)
+data ChangeLayout = FirstLayout | NextLayout deriving (Eq, Show)
 
 instance Message ChangeLayout
 
@@ -147,7 +147,7 @@ data Choose l r a = Choose CLR (l a) (r a) deriving (Read, Show)
 -- | Choose the current sub-layout (left or right) in 'Choose'.
 data CLR = CL | CR deriving (Read, Show, Eq)
 
-data NextNoWrap = NextNoWrap deriving (Eq, Show, Typeable)
+data NextNoWrap = NextNoWrap deriving (Eq, Show)
 instance Message NextNoWrap
 
 -- | A small wrapper around handleMessage, as it is tedious to write

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -8,7 +8,7 @@
 --
 -- Maintainer  :  dons@cse.unsw.edu.au
 -- Stability   :  unstable
--- Portability :  not portable, Typeable deriving, mtl, posix
+-- Portability :  not portable, mtl, posix
 --
 -- Operations.
 --


### PR DESCRIPTION
### Description

https://github.com/xmonad/xmonad-contrib/issues/548

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I tested my changes with my setup ~~[xmonad-testing](https://github.com/xmonad/xmonad-testing)~~

  - [x] I updated the `CHANGES.md` file
