### PR TITLE
Use `printf` instead of `echo` when using `xmessage`

### DIFF
--- a/man/xmonad.hs
+++ b/man/xmonad.hs
@@ -129,7 +129,7 @@ myKeys conf@(XConfig {XMonad.modMask = modm}) = M.fromList $
     , ((modm              , xK_q     ), spawn "xmonad --recompile; xmonad --restart")
 
     -- Run xmessage with a summary of the default keybindings (useful for beginners)
-    , ((modm .|. shiftMask, xK_slash ), spawn ("echo \"" ++ help ++ "\" | xmessage -file -"))
+    , ((modm .|. shiftMask, xK_slash ), spawn ("printf " ++ show help ++ " | xmessage -file -"))
     ]
     ++
 

--- a/src/XMonad/Config.hs
+++ b/src/XMonad/Config.hs
@@ -239,7 +239,7 @@ keys conf@(XConfig {XMonad.modMask = modMask}) = M.fromList $
         , (f, m) <- [(W.view, 0), (W.shift, shiftMask)]]
   where
     helpCommand :: X ()
-    helpCommand = spawn ("echo " ++ show help ++ " | xmessage -file -")
+    helpCommand = spawn ("printf " ++ show help ++ " | xmessage -file -")
 
 -- | Mouse bindings: default actions bound to mouse events
 mouseBindings :: XConfig Layout -> M.Map (KeyMask, Button) (Window -> X ())


### PR DESCRIPTION
### Description

When using `echo`, the whole message is shown in a single
line because newline is printed as "\n". We could fix this
by either removing `show` and explicitly adding `\"` before
and after the string, or, using `printf` instead of `echo`. I used
second one as it looks cleaner.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

I am not sure if I should add this to `CHANGES.md`. I will add this if you say so.