### PR TITLE
Make extensibleState primarily keyed by TypeRep instead of type names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,13 @@
     it easier for us to clean up the codebase. These can still be suppressed
     manually using an `OPTIONS_GHC` pragma with `-Wno-deprecations`.
 
+  * Extensible state type names no longer need to be unique, because the
+    `extensibleState` map in `XState` is now primarily keyed by the
+    machine-readable type representation rather than the human-readable type
+    name. Human-readable type names are still used for serialization of state
+    between restarts, and this representation now encodes module names as
+    well to avoid conflicts between types with equal names.
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -1,5 +1,5 @@
 name:               xmonad
-version:            0.16.99999
+version:            0.16.999999
 synopsis:           A tiling window manager
 description:        xmonad is a tiling window manager for X. Windows are arranged
                     automatically to tile the screen without gaps or overlap, maximising


### PR DESCRIPTION
### Description

We've been using the String we get out of `show . typeOf` as key in `extensibleState`, but that has a somewhat serious bug: it shows unqualified type names, so if two modules use the same type name, their extensible states will be stored in one place and get overwritten all the time.

To fix this, the `extensibleState` map is now primarily keyed by the TypeRep themselves, with fallback to String for not yet deserialized data. XMonad.Core now exports `showExtType` which serializes type names qualified, and this is used in `writeStateToFile`.

A simpler fix would be to just change the serialization of type names in `XMonad.Util.ExtensibleState`, but I'm afraid that might slows things down: Most types used here will start with "XMonad.", and that's a lot of useless linked-list pointer jumping.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/94
Related: https://github.com/xmonad/xmonad-contrib/pull/600

---

I must admit I don't really like the code, especially the xmonad-contrib part. There's the assumption that a Right key maps to a Right value, and Left key to Left value, but enforcing that in the types probably means adding a another field to the XState.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I updated the `CHANGES.md` file