### PR TITLE
Adds withUnfocused function to XMonad.Operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## unknown (unknown)
 
+  * Adds `withUnfocused` function to `XMonad.Operations`, allowing for
+    `X` operations to be applied to all unfocused windows.
+
   * Fixed a bug when using multiple screens with different dimensions,
     causing some floating windows to be smaller/larger than the size they
     requested.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,6 @@
 
 ## unknown (unknown)
 
-  * Adds `withUnfocused` function to `XMonad.Operations`, allowing for
-    `X` operations to be applied to all unfocused windows.
-
   * Fixed a bug when using multiple screens with different dimensions,
     causing some floating windows to be smaller/larger than the size they
     requested.
@@ -72,6 +69,9 @@
     workspace, then the visible workspaces and then hidden, to match the order
     of processing messages in `broadcastMessage`. Previously,
     `runOnWorkspaces` processed the hidden workspaces first.
+
+  * Added `withUnfocused` function to `XMonad.Operations`, allowing for
+    `X` operations to be applied to unfocused windows.
 
 ## 0.15 (September 30, 2018)
 

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -18,10 +18,11 @@ module XMonad.Operations (
     manage, unmanage, killWindow, kill, isClient,
     setInitialProperties, setWMState, setWindowBorderWithFallback,
     hide, reveal, tileWindow,
-    setTopFocus, focus, withFocused,
+    setTopFocus, focus,
 
     -- * Manage Windows
-    windows, refresh, rescreen, modifyWindowSet, windowBracket, windowBracket_, clearEvents, getCleanedScreenInfo, withUnfocused,
+    windows, refresh, rescreen, modifyWindowSet, windowBracket, windowBracket_, clearEvents, getCleanedScreenInfo,
+    withFocused, withUnfocused,
 
     -- * Keyboard and Mouse
     cleanMask, extraModifiers,
@@ -481,7 +482,7 @@ screenWorkspace sc = withWindowSet $ return . W.lookupWorkspace sc
 withFocused :: (Window -> X ()) -> X ()
 withFocused f = withWindowSet $ \w -> whenJust (W.peek w) f
 
--- | Apply an 'X' operation to all unfocused windows, if there are any.
+-- | Apply an 'X' operation to all unfocused windows on the current workspace, if there are any.
 withUnfocused :: (Window -> X ()) -> X ()
 withUnfocused f = withWindowSet $ \ws ->
     whenJust (W.peek ws) $ \w ->

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -21,7 +21,7 @@ module XMonad.Operations (
     setTopFocus, focus, withFocused,
 
     -- * Manage Windows
-    windows, refresh, rescreen, modifyWindowSet, windowBracket, windowBracket_, clearEvents, getCleanedScreenInfo,
+    windows, refresh, rescreen, modifyWindowSet, windowBracket, windowBracket_, clearEvents, getCleanedScreenInfo, withUnfocused,
 
     -- * Keyboard and Mouse
     cleanMask, extraModifiers,
@@ -480,6 +480,13 @@ screenWorkspace sc = withWindowSet $ return . W.lookupWorkspace sc
 -- | Apply an 'X' operation to the currently focused window, if there is one.
 withFocused :: (Window -> X ()) -> X ()
 withFocused f = withWindowSet $ \w -> whenJust (W.peek w) f
+
+-- | Apply an 'X' operation to all unfocused windows, if there are any.
+withUnfocused :: (Window -> X ()) -> X ()
+withUnfocused f = withWindowSet $ \ws ->
+    whenJust (W.peek ws) $ \w ->
+        let unfocusedWindows = filter (/= w) $ W.index ws
+        in mapM_ f unfocusedWindows
 
 -- | Is the window is under management by xmonad?
 isClient :: Window -> X Bool


### PR DESCRIPTION
### Description

This PR adds `withUnfocused` which allows you to apply an `X` operation to all unfocused windows. We want it to implement a `killOthers` function as discussed here: https://github.com/xmonad/xmonad-contrib/issues/527

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
