### PR TITLE
Add nix recompilation support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@
   will snap to these hints as soon as they're floated (mouse move, keybinding).
   Previously that only happened on mouse resize.
 
+* Recompilation now detects `flake.nix` and `default.nix` (can be a
+  symlink) and switches to using `nix build` as appropriate.
+
 ### Bug Fixes
 
 * Duplicated floats (e.g. from X.A.CopyToAll) no longer escape to inactive

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -33,7 +33,7 @@ module XMonad.Core (
     StateExtension(..), ExtensionClass(..), ConfExtension(..),
     runX, catchX, userCode, userCodeDef, io, catchIO, installSignalHandlers, uninstallSignalHandlers,
     withDisplay, withWindowSet, isRoot, runOnWorkspaces,
-    getAtom, spawn, spawnPID, xfork, xmessage, recompile, trace, whenJust, whenX,
+    getAtom, spawn, spawnPID, xfork, xmessage, recompile, trace, whenJust, whenX, ifM,
     getXMonadDir, getXMonadCacheDir, getXMonadDataDir, stateFileName, binFileName,
     atom_WM_STATE, atom_WM_PROTOCOLS, atom_WM_DELETE_WINDOW, atom_WM_TAKE_FOCUS, withWindowAttributes,
     ManageHook, Query(..), runQuery, Directories'(..), Directories, getDirectories,
@@ -415,9 +415,13 @@ data StateExtension =
 data ConfExtension = forall a. Typeable a => ConfExtension a
 
 -- ---------------------------------------------------------------------
--- | General utilities
---
--- Lift an 'IO' action into the 'X' monad
+-- General utilities
+
+-- | If-then-else lifted to a 'Monad'.
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM mb t f = mb >>= \b -> if b then t else f
+
+-- | Lift an 'IO' action into the 'X' monad
 io :: MonadIO m => IO a -> m a
 io = liftIO
 
@@ -709,9 +713,6 @@ compile dirs method =
               ]
     andCopyFromResultDir exitCode = do
       if exitCode == ExitSuccess then copyFromResultDir else return exitCode
-    ifM c i e = do
-      cond <- c
-      if cond then i else e
     findM p = foldr (\x -> ifM (p x) (pure $ Just x)) (pure Nothing)
     catchAny :: IO a -> (SomeException -> IO a) -> IO a
     catchAny = E.catch

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -64,10 +64,6 @@ x <&&> y = ifM x y (pure False)
 (<||>) :: Monad m => m Bool -> m Bool -> m Bool
 x <||> y = ifM x (pure True) y
 
--- | If-then-else lifted to a 'Monad'.
-ifM :: Monad m => m Bool -> m a -> m a -> m a
-ifM mb t f = mb >>= \b -> if b then t else f
-
 -- | Return the window title.
 title :: Query String
 title = ask >>= \w -> liftX $ do


### PR DESCRIPTION
### Description

This is a follow up to #318 that adds support for nix recompilation out of the box

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

I tested flake recompilation with my config and it seems to work well.

  - [x] I updated the `CHANGES.md` file
