### PR TITLE
X.Operations: Fix mouse in Tabbed decorations (revert broadcastMessage refactor)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,11 +65,6 @@
     it easier for us to clean up the codebase. These can still be suppressed
     manually using an `OPTIONS_GHC` pragma with `-Wno-deprecations`.
 
-  * `runOnWorkspaces` changed to first run the action on the current
-    workspace, then the visible workspaces and then hidden, to match the order
-    of processing messages in `broadcastMessage`. Previously,
-    `runOnWorkspaces` processed the hidden workspaces first.
-
   * Added `withUnfocused` function to `XMonad.Operations`, allowing for
     `X` operations to be applied to unfocused windows.
 

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -470,9 +470,9 @@ xmessage msg = void . xfork $ do
 runOnWorkspaces :: (WindowSpace -> X WindowSpace) -> X ()
 runOnWorkspaces job = do
     ws <- gets windowset
+    h <- mapM job $ hidden ws
     c:v <- mapM (\s -> (\w -> s { workspace = w}) <$> job (workspace s))
              $ current ws : visible ws
-    h <- mapM job $ hidden ws
     modify $ \s -> s { windowset = ws { current = c, visible = v, hidden = h } }
 
 -- | All the directories that xmonad will use.  They will be used for


### PR DESCRIPTION
### Description

Turns out there was another aspect of `broadcastMessage` behaviour that I missed in my review of the refactor: X.L.Tabbed updates the windowset during handleMessage (via `X.O.focus`) and expects that change to persist (by returning `Nothing` and hoping no other layout or layout modifier returns `Just`). That's quite a hack, but the LayoutClass interface doesn't allow a cleaner way to do this (well, some extensible state plus a custom event hook might work, but then the layout isn't self-contained any more).

And since rereading workspace layouts during `modifyLayouts` would force this back into O(n²), we might as well revert the whole refactor. :-/

Fixes: https://github.com/xmonad/xmonad/issues/329

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I updated the `CHANGES.md` file
