### PR TITLE
Updated flake.nix for full compatibility.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,18 @@
   };
   outputs = { self, flake-utils, nixpkgs, git-ignore-nix }:
   let
-    overlay = final: prev: {
-      haskellPackages = prev.haskellPackages.override (old: {
-        overrides = prev.lib.composeExtensions (old.overrides or (_: _: {}))
-        (hself: hsuper: {
-          xmonad = hself.callCabal2nix "xmonad" (git-ignore-nix.gitIgnoreSource ./.) { };
-        });
+    fn = prev: (old: {
+        overrides =
+        (prev.lib.composeExtensions (old.overrides or (_: _: {}))
+          (hself: hsuper: {
+            xmonad = hself.callCabal2nix "xmonad" (git-ignore-nix.gitIgnoreSource ./.) { };
+          })
+        );
       });
+    overlay = final: prev: {
+      ghcWithHoogle = prev.ghcWithHoogle.override (fn prev);
+      ghcWithPackages = prev.ghcWithPackages.override (fn prev);
+      haskellPackages = prev.haskellPackages.override (fn prev);
     };
     overlays = [ overlay ];
   in flake-utils.lib.eachDefaultSystem (system:


### PR DESCRIPTION
### Description


For people using nix, the overlay provided does not work with `ghcWithPackages` & `ghcWithHoogle`.

This change fixes that.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file