### PR TITLE
Make `(<&&>)` and `(<||>)` lazy in their second argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,11 @@
   * Added `withUnfocused` function to `XMonad.Operations`, allowing for
     `X` operations to be applied to unfocused windows.
 
+  * Made `(<&&>)` and `(<||>)` non-strict in their right operand; i.e.,
+    these operators now implement short-circuit evaluation so the right
+    operand is evaluated only if the left operand does not suffice to
+    determine the result.
+
 ## 0.15 (September 30, 2018)
 
   * Reimplement `sendMessage` to deal properly with windowset changes made

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -61,11 +61,15 @@ infixr 3 <&&>, <||>
 
 -- | '&&' lifted to a 'Monad'.
 (<&&>) :: Monad m => m Bool -> m Bool -> m Bool
-(<&&>) = liftM2 (&&)
+(<&&>) x y = ifM x y (pure False)
 
 -- | '||' lifted to a 'Monad'.
 (<||>) :: Monad m => m Bool -> m Bool -> m Bool
-(<||>) = liftM2 (||)
+(<||>) x y = ifM x (pure True) y
+
+-- | If-then-else lifted to a 'Monad'.
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM mb t f = mb >>= \b -> if b then t else f
 
 -- | Return the window title.
 title :: Query String


### PR DESCRIPTION
### Description

##### Commits

- Update CHANGES.md

- X.ManageHook: Make (<&&>) and (<||>) lazy in their second argument

   While an implementation of `liftM2 (&&)` may seem like a straightforward
  lift of `(&&)` into a monadic setting, it actually expands to

      (<&&>) :: Monad m => m Bool -> m Bool -> m Bool
      mb <&&> mb' = do
        a <- mb
        b <- mb'
        return (a && b)

  which runs both monadic effects first and then applies `(&&)`.

  This is fixed by introducing a monadic version of `if-then-else` (which
  is also exported due to its usefulness) that checks the second result
  only if this is explicitly necessary.

##### Other Comments

This is a breaking change[^1] but code that relies on this behaviour should, in my opinion, just be fixed.  This behaviour certainly surprises me every time we bump into it (most recently in https://github.com/xmonad/xmonad-contrib/pull/617).

[^1]: We should really separate CHANGES.md into features and breaking changes before the release, just as we do for contrib.  Makes it much easier to read.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I updated the `CHANGES.md` file

  - [n/a] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)