### PR TITLE
X.Operations: Silently catch in setWindowBorderWithFallback

### DIFF
--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -254,8 +254,7 @@ setWindowBorderWithFallback dpy w color basic = io $
       setWindowBorder dpy w pixel
   where
     fallback :: C.SomeException -> IO ()
-    fallback e = do hPrint stderr e >> hFlush stderr
-                    setWindowBorder dpy w basic
+    fallback _ = setWindowBorder dpy w basic
 
 -- | Hide a window by unmapping it and setting Iconified.
 hide :: Window -> X ()


### PR DESCRIPTION
##### X.Operations: Silently catch in setWindowBorderWithFallback

While we catch the exception that `getWindowAttributes` can throw in `setWindowBorderWithFallback`, we immediately turn around and print the error to stderr.  Since this exception is raised every time a window is closed[1] , it clutters stderr and may even confuse users as to why xmonad is throwing these exceptions.

[1]: Depending on how the window is closed, we either have no way of running `windows` on our own (say, the window is closed by a keybinding of the program itself), or the focus change (and thus the call to `windows`) runs before we can handle the DestroyWindowEvent.

##### Additional thoughts

We also wholesale print exceptions to stderr in `catchX`.  This could potentially be as confusing as what is fixed in this commit.  Instead of

``` haskell
  _ -> do hPrint stderr e; runX c st errcase
```

we could probably just do

``` haskell
  _ -> do hPutStrLn stderr ("catchX caught: " <> show e); runX c st errcase
```

to at least give some sort of indication of what actually happened.  I have no strong opinions here and so this is not a commit (yet).

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I manually checked that I now don't get any noise in my stderr file when closing a window.

  - [n/a] I updated the `CHANGES.md` file