### PR TITLE
ci: Improve release workflow

### DIFF
--- a/.github/workflows/haskell-ci-hackage.patch
+++ b/.github/workflows/haskell-ci-hackage.patch
@@ -2,14 +2,16 @@ Piggy-back on the haskell-ci workflow for automatic releases to Hackage.
 
 This extends the workflow with two additional triggers:
 
- * When a release is created on GitHub, a candidate release is uploaded to
-   Hackage and docs are submitted for it as Hackage can't build them itself
-   (https://github.com/haskell/hackage-server/issues/925).
+ * When the Haskell-CI workflow is triggered manually with a non-empty version
+   input (matching the version in the cabal file), a candidate release is
+   uploaded to Hackage and docs are submitted for it as Hackage can't build
+   them itself (https://github.com/haskell/hackage-server/issues/925).
 
- * To make a final release, the workflow can be triggered manually by entering
-   the correct version number matching the version in the cabal file. This is
-   here because promoting the candidate on Hackage discards the uploaded docs
-   (https://github.com/haskell/hackage-server/issues/70).
+   Note that promoting the candidate on Hackage discards the uploaded docs
+   (https://github.com/haskell/hackage-server/issues/70). Don't do that.
+
+ * When a release is created on GitHub, a final release is uploaded to Hackage
+   and docs are submitted for it.
 
 The automation uses a special Hackage user: https://hackage.haskell.org/user/xmonad
 and each repo (X11, xmonad, xmonad-contrib) has its own HACKAGE_API_KEY token
@@ -17,7 +19,7 @@ set in GitHub repository secrets.
 
 --- .github/workflows/haskell-ci.yml.orig
 +++ .github/workflows/haskell-ci.yml
-@@ -14,8 +14,17 @@
+@@ -14,8 +14,15 @@
  #
  name: Haskell-CI
  on:
@@ -31,21 +33,19 @@ set in GitHub repository secrets.
 +  workflow_dispatch:
 +    inputs:
 +      version:
-+        # releases to Hackage are final and cannot be reverted, thus require
-+        # manual entry of version as a poor man's mistake avoidance
-+        description: version (must match version in cabal file)
++        description: candidate version (must match version in cabal file)
  jobs:
    linux:
      name: Haskell-CI - Linux - ${{ matrix.compiler }}
-@@ -28,6 +37,7 @@
-         include:
-           - compiler: ghc-9.0.1
+@@ -31,6 +38,7 @@
+             compilerVersion: 9.0.1
+             setup-method: hvr-ppa
              allow-failure: false
 +            upload: true
            - compiler: ghc-8.10.4
-             allow-failure: false
-           - compiler: ghc-8.8.4
-@@ -171,8 +181,66 @@
+             compilerKind: ghc
+             compilerVersion: 8.10.4
+@@ -209,8 +217,66 @@
            ${CABAL} -vnormal check
        - name: haddock
          run: |
@@ -66,7 +66,7 @@ set in GitHub repository secrets.
 +        with:
 +          path: ${{ github.workspace }}/haddock/*-docs.tar.gz
 +      - name: hackage upload (candidate)
-+        if: matrix.upload && github.event_name == 'release'
++        if: matrix.upload && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
 +        run: |
 +          set -ex
 +          PACKAGE_VERSION="${PACKAGE_VERSION#v}"
@@ -88,9 +88,9 @@ set in GitHub repository secrets.
 +        env:
 +          HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
 +          PACKAGE_NAME: ${{ github.event.repository.name }}
-+          PACKAGE_VERSION: ${{ github.event.release.tag_name }}
++          PACKAGE_VERSION: ${{ github.event.inputs.version }}
 +      - name: hackage upload (release)
-+        if: matrix.upload && github.event_name == 'workflow_dispatch'
++        if: matrix.upload && github.event_name == 'release'
 +        run: |
 +          set -ex
 +          PACKAGE_VERSION="${PACKAGE_VERSION#v}"
@@ -112,4 +112,4 @@ set in GitHub repository secrets.
 +        env:
 +          HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
 +          PACKAGE_NAME: ${{ github.event.repository.name }}
-+          PACKAGE_VERSION: ${{ github.event.inputs.version }}
++          PACKAGE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/haskell-ci-hackage.patch
+++ b/.github/workflows/haskell-ci-hackage.patch
@@ -45,7 +45,7 @@ set in GitHub repository secrets.
            - compiler: ghc-8.10.4
              compilerKind: ghc
              compilerVersion: 8.10.4
-@@ -209,8 +217,66 @@
+@@ -209,8 +217,80 @@
            ${CABAL} -vnormal check
        - name: haddock
          run: |
@@ -67,48 +67,62 @@ set in GitHub repository secrets.
 +          path: ${{ github.workspace }}/haddock/*-docs.tar.gz
 +      - name: hackage upload (candidate)
 +        if: matrix.upload && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
++        shell: bash
 +        run: |
 +          set -ex
 +          PACKAGE_VERSION="${PACKAGE_VERSION#v}"
-+          curl \
-+            --silent --show-error --fail \
-+            --header "Accept: text/plain" \
-+            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-+            --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
-+            https://hackage.haskell.org/packages/candidates/
-+          curl \
-+            --silent --show-error --fail \
-+            -X PUT \
-+            --header "Accept: text/plain" \
-+            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-+            --header "Content-Type: application/x-tar" \
-+            --header "Content-Encoding: gzip" \
-+            --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
-+            https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/candidate/docs
++          res=$(
++            curl \
++              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
++              --header "Accept: text/plain" \
++              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
++              --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
++              https://hackage.haskell.org/packages/candidates/
++          )
++          [[ $res == 2?? ]]  # TODO: --fail-with-body once curl 7.76.0 is available
++          res=$(
++            curl \
++              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
++              -X PUT \
++              --header "Accept: text/plain" \
++              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
++              --header "Content-Type: application/x-tar" \
++              --header "Content-Encoding: gzip" \
++              --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
++              https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/candidate/docs
++          )
++          [[ $res == 2?? ]]
 +        env:
 +          HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
 +          PACKAGE_NAME: ${{ github.event.repository.name }}
 +          PACKAGE_VERSION: ${{ github.event.inputs.version }}
 +      - name: hackage upload (release)
 +        if: matrix.upload && github.event_name == 'release'
++        shell: bash
 +        run: |
 +          set -ex
 +          PACKAGE_VERSION="${PACKAGE_VERSION#v}"
-+          curl \
-+            --silent --show-error --fail \
-+            --header "Accept: text/plain" \
-+            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-+            --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
-+            https://hackage.haskell.org/packages/
-+          curl \
-+            --silent --show-error --fail \
-+            -X PUT \
-+            --header "Accept: text/plain" \
-+            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-+            --header "Content-Type: application/x-tar" \
-+            --header "Content-Encoding: gzip" \
-+            --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
-+            https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/docs
++          res=$(
++            curl \
++              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
++              --header "Accept: text/plain" \
++              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
++              --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
++              https://hackage.haskell.org/packages/
++          )
++          [[ $res == 2?? ]]  # TODO: --fail-with-body once curl 7.76.0 is available
++          res=$(
++            curl \
++              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
++              -X PUT \
++              --header "Accept: text/plain" \
++              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
++              --header "Content-Type: application/x-tar" \
++              --header "Content-Encoding: gzip" \
++              --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
++              https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/docs
++          )
++          [[ $res == 2?? ]]
 +        env:
 +          HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
 +          PACKAGE_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -245,48 +245,62 @@ jobs:
           path: ${{ github.workspace }}/haddock/*-docs.tar.gz
       - name: hackage upload (candidate)
         if: matrix.upload && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+        shell: bash
         run: |
           set -ex
           PACKAGE_VERSION="${PACKAGE_VERSION#v}"
-          curl \
-            --silent --show-error --fail \
-            --header "Accept: text/plain" \
-            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-            --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
-            https://hackage.haskell.org/packages/candidates/
-          curl \
-            --silent --show-error --fail \
-            -X PUT \
-            --header "Accept: text/plain" \
-            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-            --header "Content-Type: application/x-tar" \
-            --header "Content-Encoding: gzip" \
-            --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
-            https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/candidate/docs
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
+              https://hackage.haskell.org/packages/candidates/
+          )
+          [[ $res == 2?? ]]  # TODO: --fail-with-body once curl 7.76.0 is available
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              -X PUT \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --header "Content-Type: application/x-tar" \
+              --header "Content-Encoding: gzip" \
+              --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
+              https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/candidate/docs
+          )
+          [[ $res == 2?? ]]
         env:
           HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
           PACKAGE_NAME: ${{ github.event.repository.name }}
           PACKAGE_VERSION: ${{ github.event.inputs.version }}
       - name: hackage upload (release)
         if: matrix.upload && github.event_name == 'release'
+        shell: bash
         run: |
           set -ex
           PACKAGE_VERSION="${PACKAGE_VERSION#v}"
-          curl \
-            --silent --show-error --fail \
-            --header "Accept: text/plain" \
-            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-            --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
-            https://hackage.haskell.org/packages/
-          curl \
-            --silent --show-error --fail \
-            -X PUT \
-            --header "Accept: text/plain" \
-            --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
-            --header "Content-Type: application/x-tar" \
-            --header "Content-Encoding: gzip" \
-            --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
-            https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/docs
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
+              https://hackage.haskell.org/packages/
+          )
+          [[ $res == 2?? ]]  # TODO: --fail-with-body once curl 7.76.0 is available
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              -X PUT \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --header "Content-Type: application/x-tar" \
+              --header "Content-Encoding: gzip" \
+              --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
+              https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/docs
+          )
+          [[ $res == 2?? ]]
         env:
           HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
           PACKAGE_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -22,9 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        # releases to Hackage are final and cannot be reverted, thus require
-        # manual entry of version as a poor man's mistake avoidance
-        description: version (must match version in cabal file)
+        description: candidate version (must match version in cabal file)
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -246,7 +244,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/haddock/*-docs.tar.gz
       - name: hackage upload (candidate)
-        if: matrix.upload && github.event_name == 'release'
+        if: matrix.upload && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
         run: |
           set -ex
           PACKAGE_VERSION="${PACKAGE_VERSION#v}"
@@ -268,9 +266,9 @@ jobs:
         env:
           HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
           PACKAGE_NAME: ${{ github.event.repository.name }}
-          PACKAGE_VERSION: ${{ github.event.release.tag_name }}
+          PACKAGE_VERSION: ${{ github.event.inputs.version }}
       - name: hackage upload (release)
-        if: matrix.upload && github.event_name == 'workflow_dispatch'
+        if: matrix.upload && github.event_name == 'release'
         run: |
           set -ex
           PACKAGE_VERSION="${PACKAGE_VERSION#v}"
@@ -292,4 +290,4 @@ jobs:
         env:
           HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
           PACKAGE_NAME: ${{ github.event.repository.name }}
-          PACKAGE_VERSION: ${{ github.event.inputs.version }}
+          PACKAGE_VERSION: ${{ github.event.release.tag_name }}

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -83,19 +83,21 @@ When the time comes to release another version of xmonad and xmonad-contrib:
      versions and that `.github/workflows/stack.yml` tests with several recent
      revisions of [Stackage][] LTS.
 
-  4. Create a release on GitHub:
-
-     - https://github.com/xmonad/xmonad/releases/new
-     - https://github.com/xmonad/xmonad-contrib/releases/new
-
-     CI will upload a release candidate to Hackage. Check again that
-     everything looks good. To publish a final release, run the CI workflow
-     once again with the correct version number:
+  4. Trigger the Haskell-CI workflow and fill in the candidate version number.
+     This will upload a release candidate to Hackage.
 
      - https://github.com/xmonad/xmonad/actions/workflows/haskell-ci.yml
      - https://github.com/xmonad/xmonad-contrib/actions/workflows/haskell-ci.yml
 
-     See [haskell-ci-hackage.patch][] for details about the release infrastructure.
+     Check that everything looks good. If not, push fixes and do another
+     candidate. When everything's ready, create a release on GitHub:
+
+     - https://github.com/xmonad/xmonad/releases/new
+     - https://github.com/xmonad/xmonad-contrib/releases/new
+
+     CI will automatically upload the final release to Hackage.
+
+     See [haskell-ci-hackage.patch][] for details about the Hackage automation.
 
   5. Update the website:
 


### PR DESCRIPTION
#### [ci: Update haskell-ci](../commit/c6592d6285a591d3c584bba3af0bb08f0e32a403)


#### [ci: Swap candidate/final release logic](../commit/cda4a52d3e28ebecdcc2bf13ace1d75348cf06c2)

During the release of xmonad 0.17.0, I realized that we need to be able to upload candidates before tagging the release on GitHub, because there might be issues with the tarball and Hackage may reject it. When that happened, I had to remove the release, delete the tag, upload the candidate manually to see what's wrong with it, try to fix it, upload it manually again, and so on.

This commit swaps the logic: when the workflow is invoked manually, it uploads the candidate. This can be done multiple times, and once everything is fine, the release can finally be tagged and it's released to Hackage proper. The only disadvantage is that we need to remember to try uploading the candidate. Not sure if there's a perfect solution…

#### [ci: Show error body from Hackage when it fails](../commit/58aae1875e7da3c3991e0daafdf8820821c387d5)

Prevents having to upload the candidate manually to see what's wrong.

#### [MAINTAINERS: Update the Hackage release step](../commit/5ce1957bb4ee9f2ff215db081762e8025a0c63c0)
