### PR TITLE
X.Operations: Make window borders opaque

### DIFF
--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -250,7 +250,7 @@ setWindowBorderWithFallback :: Display -> Window -> String -> Pixel -> X ()
 setWindowBorderWithFallback dpy w color basic = io $
     C.handle fallback $ do
       wa <- getWindowAttributes dpy w
-      pixel <- color_pixel . fst <$> allocNamedColor dpy (wa_colormap wa) color
+      pixel <- setPixelSolid . color_pixel . fst <$> allocNamedColor dpy (wa_colormap wa) color
       setWindowBorder dpy w pixel
   where
     fallback :: C.SomeException -> IO ()
@@ -504,10 +504,14 @@ cleanMask km = do
     nlm <- gets numberlockMask
     return (complement (nlm .|. lockMask) .&. km)
 
+-- | Set the 'Pixel' alpha value to 255.
+setPixelSolid :: Pixel -> Pixel
+setPixelSolid p = (p .|. 0xff000000)
+
 -- | Get the 'Pixel' value for a named color.
 initColor :: Display -> String -> IO (Maybe Pixel)
 initColor dpy c = C.handle (\(C.SomeException _) -> return Nothing) $
-    (Just . color_pixel . fst) <$> allocNamedColor dpy colormap c
+    (Just . setPixelSolid . color_pixel . fst) <$> allocNamedColor dpy colormap c
     where colormap = defaultColormap dpy (defaultScreen dpy)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
### Description

The alpha wasn't set in the border, making the border color inconsistent when using transparent windows. This patch sets the border alpha to 0xff.

#### Before
![image](https://user-images.githubusercontent.com/19158283/142265799-a92327ea-1ffc-41bc-8f32-502700d1f123.png)

#### After
![image](https://user-images.githubusercontent.com/19158283/142265898-784783b9-05c2-4357-a616-85705a53c183.png)

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Open a transparent application and a non-transparent application (just like Firefox), now the border transparency is consistent between the two applications.

  - [N/A] I updated the `CHANGES.md` file
