### PR TITLE
X.Operations: Use custom cursor for dragging/resizing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## unknown
 
+### Enhancements
+
+  * Added custom cursor shapes for resizing and moving windows.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Enhancements


### PR DESCRIPTION
### Description

When dragging and resizing windows, users may expect the cursor to
change to indicate the respective behaviour.  In particular, many other
window managers already do this [1] [2].

Thus, introduce a new (non-exported) `mouseDragCursor` function that
takes a cursor shape and change the generic resize and move functions to
use that.  The reason that we don't change `mouseDrag` itself (for now)
is that this is exported and quite a few contrib modules use it—breaking
compatibility with xmonad-0.17.0 so soon after the release seems unwise.

Fixes: https://github.com/xmonad/xmonad/issues/348

[1]: https://git.suckless.org/dwm/file/dwm.c.html#l1567
[2]: https://github.com/awesomeWM/awesome/blob/7a8fa9d27a7907ab81e60274c925ba65d10015aa/lib/awful/mouse/resize.lua#L23

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Manually; the cursors appear as expected

  - [x] I updated the `CHANGES.md` file