### PR TITLE
Fix nix flake compilation.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
       haskellPackages = prev.haskellPackages.override (old: {
         overrides = prev.lib.composeExtensions (old.overrides or (_: _: {}))
         (hself: hsuper: {
-          xmonad = hself.callCabal2nix "xmonad" (git-ignore-nix.gitIgnoreSource ./.) { };
+          xmonad = hself.callCabal2nix "xmonad" (git-ignore-nix.lib.gitignoreSource ./.) { };
         });
       });
     };


### PR DESCRIPTION
### Description

Was no longer compiling, attribute `gitIgnoreSource` didn't exist, it was moved to `lib.gitignoreSource`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: unit &/or manually.

  - [ ] I updated the `CHANGES.md` file

Not sure that last checkbox is relevant here.