### PR TITLE
Add function to detect floating windows in ManageHook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,9 @@
   * Added `withUnfocused` function to `XMonad.Operations`, allowing for `X`
     operations to be applied to unfocused windows.
 
+  * Added `willFloat` function to `XMonad.ManageHooks` to detect whether the
+    (about to be) managed window will be a floating window or not
+
 [these build scripts]: https://github.com/xmonad/xmonad-testing/tree/master/build-scripts
 
 ### Bug Fixes

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -106,6 +106,14 @@ getStringProperty d w p = do
   md <- io $ getWindowProperty8 d a w
   return $ fmap (map (toEnum . fromIntegral)) md
 
+-- | Return whether the window will be a floating window or not
+willFloat :: Query Bool
+willFloat = ask >>= \w -> liftX $ withDisplay $ \d -> do
+  sh <- io $ getWMNormalHints d w
+  let isFixedSize = isJust (sh_min_size sh) && sh_min_size sh == sh_max_size sh
+  isTransient <- isJust <$> io (getTransientForHint d w)
+  return (isFixedSize || isTransient)
+
 -- | Modify the 'WindowSet' with a pure function.
 doF :: (s -> s) -> Query (Endo s)
 doF = return . Endo

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -27,7 +27,7 @@ import Control.Monad.Reader
 import Data.Maybe
 import Data.Monoid
 import qualified XMonad.StackSet as W
-import XMonad.Operations (floatLocation, reveal)
+import XMonad.Operations (floatLocation, reveal, isFixedSizeOrTransient)
 
 -- | Lift an 'X' action to a 'Query'.
 liftX :: X a -> Query a
@@ -108,11 +108,7 @@ getStringProperty d w p = do
 
 -- | Return whether the window will be a floating window or not
 willFloat :: Query Bool
-willFloat = ask >>= \w -> liftX $ withDisplay $ \d -> do
-  sh <- io $ getWMNormalHints d w
-  let isFixedSize = isJust (sh_min_size sh) && sh_min_size sh == sh_max_size sh
-  isTransient <- isJust <$> io (getTransientForHint d w)
-  return (isFixedSize || isTransient)
+willFloat = ask >>= \w -> liftX $ withDisplay $ \d -> isFixedSizeOrTransient d w
 
 -- | Modify the 'WindowSet' with a pure function.
 doF :: (s -> s) -> Query (Endo s)


### PR DESCRIPTION
This PR adds a function to `ManageHooks` to check whether the window to be managed is going to be a floating window or not. This feature and the problem it addresses are described more in detail in issue #300. An example configuration and an example use case are described in the issue. Under suggestion of @slotThe I decided to turn that issue into an actual PR for xmonad core. I've run the added code against the unit tests and nothing broke. I also made sure to test it manually using Xephyr to confirm that it was in fact doing what it tries to achieve.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: unit testing + manual testing

  - [x] I updated the `CHANGES.md` file
