### PR TITLE
Cabal build support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+  * Added support for automated builds using cabal, if a `cabal.project`
+    file is present. This mirrors the existing stack support.
+
   * Added custom cursor shapes for resizing and moving windows.
 
 ### Bug Fixes

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -665,7 +665,7 @@ compile dirs method =
                 CompileGhc ->
                     run "ghc" ghcArgs
                 CompileCabalGhc cabalProject ->
-                    run "cabal" ["build", "-v0", "--project-file=" ++ cabalProject] .&&.
+                    run "cabal" ["build", "all", "-v0", "--project-file=" ++ cabalProject] .&&.
                     run "cabal" ("exec" : "ghc" : ("--project-file=" ++ cabalProject) : "--" : ghcArgs)
                 CompileStackGhc stackYaml ->
                     run "stack" ["build", "--silent", "--stack-yaml", stackYaml] .&&.


### PR DESCRIPTION
### Description

Add support for cabal builds based on presence of a `cabal.project` file, analogous to our support for stack builds based on `stack.yaml`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: needs manual testing

  - [x] I updated the `CHANGES.md` file
