### PR TITLE
Apply Patch in Nix Flake; Enable Configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,5 @@
-# This file is maintained by @IvanMalison (github)
+# This file is maintained by @IvanMalison and @LSLeary (github)
+# See xmonad-contrib/NIX.md for an overview of module usage.
 {
   inputs = {
     flake-utils.url = github:numtide/flake-utils;


### PR DESCRIPTION
### Description

(tldr; extended the flake to make xmonad from git master a fully functioning drop-in replacement on nixos.)

#### Commit 1: Patching

Currently, `nix.flake` does not apply the nixpkgs patch to the xmonad source. That's perhaps fine for `defaultPackage`, but the derivation overlaid into `haskellPackages` should be patched properly so it can be used. To get the most up-to-date patch, I pull from unstable.

Further refactoring foreshadows the latter two commits.

#### Commit 2: Configurability

With the first change, the xmonad provided by the overlay can compile its config, but only against the default compiler.
It's possible to hack around the overlay to change that, but who wants to hack?
By splitting `overlay` into `fromHOL` and `hoverlay` and taking a `compiler` argument, the desired overlay can be built.

#### Commit 3: Cleanliness

NixOS, however, allows much cleaner modes of configuration via *modules*.
The flake now provides one, utilising the machinery from the second commit on the end user's behalf.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX
    - Tested to function as intended on my system.

  - [ ] I updated the `CHANGES.md` file
    - As a peripheral change—not one to xmonad itself—I presume this would be misplaced in `CHANGES.md`.