### PR TITLE
X.Operations: Export setNumlockMask, grabKeys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
   * Added custom cursor shapes for resizing and moving windows.
 
+  * Exported `cacheNumlockMask` and `mkGrabs` from `XMonad.Operations`.
+
 ### Bug Fixes
 
   * Fixed border color of windows with alpha channel. Now all windows have the


### PR DESCRIPTION
### Description

As discussed in xmonad/xmonad-contrib/#703, certain functions that
X.U.Grab has vendored should really just be exported from core.

Related: https://github.com/xmonad/xmonad-contrib/pull/703

---

I'm not sure about a contrib PR right now, since we'd then again have to depend on xmonad 0.17.1 (let's say) for contrib 0.17.1; might not be a good look for a minor version bump?  Probably best to wait for 0.18.0 or something (opinions welcome, though)

---

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested manually (and am running this right now); seems fine.

  - [x] I updated the `CHANGES.md` file