### PR TITLE
Fix Nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,10 @@
           overrides = composeExtensions (old.overrides or (_: _: {}))
             (hol final prev);
         }));
-    patch = unstable
-          + "/pkgs/development/haskell-modules/patches/xmonad_0_17_0-nix.patch";
     hoverlay = final: prev: hself: hsuper:
       with prev.haskell.lib.compose; {
-      xmonad = appendPatch patch
-        (hself.callCabal2nix "xmonad"
-          (git-ignore-nix.lib.gitignoreSource ./.) { });
+        xmonad = hself.callCabal2nix "xmonad"
+          (git-ignore-nix.lib.gitignoreSource ./.) { };
       };
     overlay = fromHOL hoverlay { };
     overlays = [ overlay ];


### PR DESCRIPTION
### Description
As advised in https://github.com/NixOS/nixpkgs/commit/36d5761b3e5aca9742fec85107e3d308a9af872c this PR provides a way to set the path for `xmessage` and `ghc` binaries via environment variables `XMONAD_XMESSAGE` and `XMONAD_GHC`.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
