### PR TITLE
Fixes and Workarounds in flake.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tags
 /cabal.sandbox.config
 /dist-newstyle/
 /dist/
+
+# nix artifacts
+result


### PR DESCRIPTION
### Description

Sister PR to: xmonad/xmonad-contrib#750

  - There's a "gotcha" when writing overlays for nested attributes, since their changes are composed in with `//` rather than `recursiveUpdate`. `fromHOL` was mangling some stuff we weren't using. Now, it isn't.
  - Though we had the `comp`/`hpath` architecture for the NixOS module, there was no easy way to exploit it for development. `comp.nix` is the simplest means to remedy this in the meantime, but I plan to remove it when I can offer a better way.
  - We now use the `XMONAD_GHC` env var and so does NixOS unstable, but stable is another matter. For recompilation to work with xmonad from git on NixOS stable, a workaround is necessary, so rather than expect people to copy paste it from `NIX.md` and incorporate it correctly, I opt to provide it from the flake itself as `modernise`. Unfortunately, it needs the `system`, so it can't be transparently included in `xmonad.nixosModules` without turning it into `xmonad.nixosModules.${system}`. The latter seems like a breach of expectations to me, but I'm not sure about that.

I should also note that the flake has accrued a fair bit of complexity at this point. I plan to extract out some parts that aren't xmonad-specific into a library flake, but I ought to work on a flakier version of the compiler selection mechanism first.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit, manually, ...) and concluded: my system (that depends on the flake and sets `xmonad.flake` options) builds and xmonad recompiles as expected.

  - [ ] I updated the `CHANGES.md` file
      - N/A
