### PR TITLE
Expose buildLaunch, sendRestart, and sendReplace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 ### Enhancements
 
+* Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
+
+* Exported `buildLaunch` from `XMonad.Main`.
+
 ### Bug Fixes
 
 ## 0.17.1 (September 3, 2022)


### PR DESCRIPTION
This is a PR as perhaps there is still some need for discussion.

Closes: https://github.com/xmonad/xmonad/issues/416

#### Commit Summary

###### Expose buildLaunch, sendRestart, and sendReplace

+ Move sendRestart and sendRestart to X.Operations, as this seems like a
  better fit.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: the functions are indeed exported.

  - [x] I updated the `CHANGES.md` file