### PR TITLE
Fix compatibilities with mtl 2.3.1

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -44,9 +44,10 @@ import Control.Exception (fromException, try, bracket_, throw, finally, SomeExce
 import qualified Control.Exception as E
 import Control.Applicative ((<|>), empty)
 import Control.Monad.Fail
+import Control.Monad.Fix (fix)
 import Control.Monad.State
 import Control.Monad.Reader
-import Control.Monad (void)
+import Control.Monad (filterM, guard, liftM2, void, when)
 import Data.Semigroup
 import Data.Traversable (for)
 import Data.Time.Clock (UTCTime)

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -26,6 +26,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Control.Monad.Reader
 import Control.Monad.State
+import Control.Monad (filterM, guard, unless, void, when)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Monoid (getAll)
 

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -71,9 +71,10 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 
 import Control.Arrow (second)
+import Control.Monad.Fix (fix)
 import Control.Monad.Reader
 import Control.Monad.State
-import Control.Monad (void)
+import Control.Monad (forM, forM_, guard, join, unless, void, when)
 import qualified Control.Exception as C
 
 import System.IO


### PR DESCRIPTION
### Description

No longer mtl version 2.3.1 re-exports Control.Monad, Control.Monad.Fix and Data.Monoid modules, so we need to import them directly instead.

I confirmed this fix by running the command below.

```sh
cabal build --flags=pedantic --constraint='mtl >= 2.3.1'
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
