### PR TITLE
Fix compatibilities with unix 2.8.0.0

### DIFF
--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -452,7 +453,11 @@ xfork x = io . forkProcess . finally nullStdin $ do
                 x
  where
     nullStdin = do
+#if MIN_VERSION_unix(2,8,0)
+        fd <- openFd "/dev/null" ReadOnly defaultFileFlags
+#else
         fd <- openFd "/dev/null" ReadOnly Nothing defaultFileFlags
+#endif
         dupTo fd stdInput
         closeFd fd
 


### PR DESCRIPTION
### Description

The version of unix removes the 3rd Maybe FileMode argument of openFd, so we need to handle this breaking change using a MIN_VERSION macro. The argument is integrated with the OpenFileFlags argument and the integrated value in defaultFileFlags is Nothing, so there's no difference between the two function calls.

I tested this change by running the command below.

```sh
cabal build --flags=pedantic --constraint='unix >= 2.8'
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
