### PR TITLE
Drop support for GHC 8.4

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -66,11 +66,6 @@ jobs:
             compilerVersion: 8.6.5
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.4.4
-            compilerKind: ghc
-            compilerVersion: 8.4.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20221009
+# version: 0.15.202211107
 #
-# REGENDATA ("0.15.20221009",["github","cabal.project"])
+# REGENDATA ("0.15.202211107",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -40,9 +40,9 @@ jobs:
             compilerVersion: 9.4.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -17,6 +17,7 @@ jobs:
           - resolver: lts-16  # GHC 8.8
           - resolver: lts-18  # GHC 8.10
           - resolver: lts-19  # GHC 9.0
+          - resolver: lts-20  # GHC 9.2
 
     steps:
       - name: Clone project

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - resolver: lts-12  # GHC 8.4
           - resolver: lts-14  # GHC 8.6
           - resolver: lts-16  # GHC 8.8
           - resolver: lts-18  # GHC 8.10

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+* Dropped support for GHC 8.4.
+
 ### Enhancements
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.6
+resolver: lts-20.0
 
 packages:
 - ./

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,13 +6,6 @@ packages:
 extra-deps:
 - X11-1.10
 
-flags:
-  xmonad:
-    # stack doesn't support automatic flags
-    # https://cabal.readthedocs.io/en/latest/cabal-package.html#resolution-of-conditions-and-flags
-    # https://github.com/commercialhaskell/stack/issues/1313#issuecomment-157259270
-    quickcheck-classes: false
-
 nix:
   packages:
     - zlib

--- a/tests/Properties/Stack.hs
+++ b/tests/Properties/Stack.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
-#ifdef VERSION_quickcheck_classes
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-#endif
 
 module Properties.Stack where
 
@@ -15,13 +11,11 @@ import qualified XMonad.StackSet as S (filter)
 
 import Data.Maybe
 
-#ifdef VERSION_quickcheck_classes
 import Data.Proxy
 import Test.QuickCheck.Classes (
     Laws (lawsTypeclass, lawsProperties), Proxy1 (Proxy1),
     foldableLaws, traversableLaws,
     )
-#endif
 
 
 -- The list returned by index should be the same length as the actual
@@ -65,7 +59,6 @@ prop_differentiate xs =
     where _ = xs :: [Int]
 
 
-#ifdef VERSION_quickcheck_classes
 -- Check type class laws of 'Data.Foldable.Foldable' and 'Data.Traversable.Traversable'.
 newtype TestStack a = TestStack (Stack a)
     deriving (Eq, Read, Show, Foldable, Functor)
@@ -82,6 +75,3 @@ prop_laws_Stack = format (foldableLaws p) <> format (traversableLaws p)
     p = Proxy :: Proxy TestStack
     format laws = [ ("Stack: " <> lawsTypeclass laws <> ": " <> name, prop)
                   | (name, prop) <- lawsProperties laws ]
-#else
-prop_laws_Stack = []
-#endif

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -27,7 +27,7 @@ author:             Spencer Janssen, Don Stewart, Adam Vogt, David Roundy, Jason
                     Ondřej Súkup, Paul Hebble, Shachaf Ben-Kiki, Siim Põder, Tim McIver,
                     Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman
 maintainer:         xmonad@haskell.org
-tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.4 || == 9.4.2
+tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.2
 category:           System
 homepage:           http://xmonad.org
 bug-reports:        https://github.com/xmonad/xmonad/issues

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -27,7 +27,7 @@ author:             Spencer Janssen, Don Stewart, Adam Vogt, David Roundy, Jason
                     Ondřej Súkup, Paul Hebble, Shachaf Ben-Kiki, Siim Põder, Tim McIver,
                     Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman
 maintainer:         xmonad@haskell.org
-tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.2
+tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.2
 category:           System
 homepage:           http://xmonad.org
 bug-reports:        https://github.com/xmonad/xmonad/issues
@@ -53,8 +53,6 @@ flag pedantic
   description: Be pedantic (-Werror and the like)
   default:     False
   manual:      True
-
-flag quickcheck-classes
 
 library
   exposed-modules: XMonad
@@ -83,7 +81,7 @@ library
   default-language: Haskell2010
 
   -- Keep this in sync with the oldest version in 'tested-with'
-  if impl(ghc > 8.4.4)
+  if impl(ghc > 8.6.5)
     ghc-options:   -Wno-unused-imports
 
   if flag(pedantic)
@@ -96,7 +94,7 @@ executable xmonad
   default-language: Haskell2010
 
   -- Keep this in sync with the oldest version in 'tested-with'
-  if impl(ghc > 8.4.4)
+  if impl(ghc > 8.6.5)
     ghc-options:   -Wno-unused-imports
 
   if flag(pedantic)
@@ -125,15 +123,11 @@ test-suite properties
   hs-source-dirs: tests
   build-depends:  base
                 , QuickCheck >= 2
+                , quickcheck-classes >= 0.4.3
                 , X11
                 , containers
                 , xmonad
   default-language: Haskell2010
-
-  if flag(quickcheck-classes) && impl(ghc > 8.5)
-    -- no quickcheck-classes in LTS-12
-    -- GHC 8.4 and lower needs too much boilerplate (Eq1, Show1, …)
-    build-depends: quickcheck-classes >= 0.4.3
 
   if flag(pedantic)
     ghc-options:   -Werror


### PR DESCRIPTION
### Description

Now that Debian has 8.6, it's time to drop 8.4.

#### Commit Summary

##### 7871950 ci: Update to GHC 9.2.5

+ A new stackage LTS is out with GHC 9.2.5, so test for this.
+ Update the haskell-ci jobs accordingly from 9.2.4.

##### 5c7c280 ci: Drop support for GHC 8.4

Debian stable is not on 8.6, which was always our guide as to which GHC
versions we want to support.

In particular, this lets us get rid of all the quickcheck-classes
special treatment.

Related: https://github.com/xmonad/xmonad/commit/400730fe3b8aab8e7f9403215c88b37e44fe7a66

##### cd86480 Use DerivingVia for obvious instances

Certain instance definitions are so automatic, they should be derivable.
Starting with GHC 8.6, they are!

##### 2f2d105 origin/drop-8.4 stack: Bump resolver to lts-20.0

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: compiles :)

  - [x] I updated the `CHANGES.md` file