### PR TITLE
Model–View Deviation Tracking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,28 @@
 
 ### Breaking Changes
 
+* MVDT:
+
+    * The type of `runX` has changed.
+
+    * `windows` no longer performs an immediate refresh, but requests one.
+      That request is handled by `handleRefresh`.
+
+    * Deprecated `modifyWindowSet`, `windowBracket`, `windowBracket_` and
+      `sendMessageWithNoRefresh`.
+
+    * Extended `XConf` with a new `internal` field.
+
 * Dropped support for GHC 8.4.
 
 ### Enhancements
+
+* MVDT:
+
+    * X actions can now be combined without performing spurious refreshes.
+
+    * New operations: `norefresh`, `handleRefresh`, `respace`,
+      `messageWorkspace` and `rendered`.
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
 

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -39,6 +39,7 @@ module XMonad.Core (
     ManageHook, Query(..), runQuery, Directories'(..), Directories, getDirectories,
   ) where
 
+import XMonad.Internal.Core (Internal)
 import XMonad.StackSet hiding (modify)
 
 import Prelude
@@ -106,6 +107,7 @@ data XConf = XConf
                                       -- the event currently being processed
     , currentEvent :: !(Maybe Event)  -- ^ event currently being processed
     , directories  :: !Directories    -- ^ directories to use
+    , internal     :: !(Internal WindowSet) -- ^ a hiding place for internals
     }
 
 -- todo, better name

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -47,10 +47,9 @@ import qualified Control.Exception as E
 import Control.Applicative ((<|>), empty)
 import Control.Monad.Fail
 import Control.Monad.Fix (fix)
-import Control.Monad.State
+import Control.Monad.RWS
 import Control.Monad.Reader
 import Control.Monad (filterM, guard, void, when)
-import Data.Semigroup
 import Data.Traversable (for)
 import Data.Time.Clock (UTCTime)
 import Data.Default.Class
@@ -157,16 +156,19 @@ newtype ScreenDetail = SD { screenRect :: Rectangle }
 
 ------------------------------------------------------------------------
 
--- | The X monad, 'ReaderT' and 'StateT' transformers over 'IO'
--- encapsulating the window manager configuration and state,
--- respectively.
+-- | The X monad; 'RWST' transformer over 'IO' encapsulating the window manager
+-- configuration, model--view deviation and state, respectively.
 --
--- Dynamic components may be retrieved with 'get', static components
--- with 'ask'. With newtype deriving we get readers and state monads
--- instantiated on 'XConf' and 'XState' automatically.
+-- Dynamic components may be retrieved with 'get' and 'listen', static
+-- components with 'ask'. With newtype deriving we get readers, writers and
+-- state monads instantiated on 'XConf', 'Any' and 'XState' automatically.
 --
-newtype X a = X (ReaderT XConf (StateT XState IO) a)
-    deriving (Functor, Applicative, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf)
+newtype X a = X (RWST XConf Any XState IO a)
+    deriving
+      ( Functor, Applicative, Monad, MonadFail, MonadIO
+      , MonadReader XConf, MonadWriter Any, MonadState XState
+      , MonadRWS XConf Any XState
+      )
     deriving (Semigroup, Monoid) via Ap X a
 
 instance Default a => Default (X a) where
@@ -184,9 +186,9 @@ instance Default a => Default (Query a) where
     def = return def
 
 -- | Run the 'X' monad, given a chunk of 'X' monad code, and an initial state
--- Return the result, and final state
-runX :: XConf -> XState -> X a -> IO (a, XState)
-runX c st (X a) = runStateT (runReaderT a c) st
+-- Return the result, final state and model--view deviation.
+runX :: XConf -> XState -> X a -> IO (a, XState, Any)
+runX c st (X rwsa) = runRWST rwsa c st
 
 -- | Run in the 'X' monad, and in case of exception, and catch it and log it
 -- to stderr, and run the error case.
@@ -194,9 +196,10 @@ catchX :: X a -> X a -> X a
 catchX job errcase = do
     st <- get
     c <- ask
-    (a, s') <- io $ runX c st job `E.catch` \e -> case fromException e of
+    (a, s', mvd) <- io $ runX c st job `E.catch` \e -> case fromException e of
                         Just (_ :: ExitCode) -> throw e
                         _ -> do hPrint stderr e; runX c st errcase
+    tell mvd
     put s'
     return a
 

--- a/src/XMonad/Internal/Core.hs
+++ b/src/XMonad/Internal/Core.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module XMonad.Internal.Core
+  ( Internal, unsafeMakeInternal
+  , readView, unsafeWriteView
+  ) where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+
+-- | An opaque data type for holding state and configuration that isn't to be
+--   laid bare to the world outside, nor even to the rest of the package if we
+--   can help it.
+newtype Internal model = Internal
+  { view :: IORef model -- ^ An 'IORef' to which we log the state of the view.
+  }
+
+-- | The ability to construct an 'Internal' allows one to play tricks with
+--   'local'.
+unsafeMakeInternal :: model -> IO (Internal model)
+unsafeMakeInternal model = do
+  viewRef <- newIORef model
+  pure Internal
+    { view = viewRef
+    }
+
+readView :: Internal model -> IO model
+readView Internal{view} = readIORef view
+
+-- | The 'view' ref can only be safely written to with a just-rendered model.
+unsafeWriteView :: Internal model -> model -> IO ()
+unsafeWriteView Internal{view} = writeIORef view
+

--- a/src/XMonad/Internal/Operations.hs
+++ b/src/XMonad/Internal/Operations.hs
@@ -1,0 +1,18 @@
+
+module XMonad.Internal.Operations
+  ( rendered, unsafeLogView
+  ) where
+
+import Control.Monad.Reader (asks)
+import XMonad.Internal.Core (readView, unsafeWriteView)
+import XMonad.Core (X, WindowSet, internal, io, withWindowSet)
+
+-- | Examine the 'WindowSet' that's currently rendered.
+rendered :: X WindowSet
+rendered = asks internal >>= io . readView
+
+-- | See 'unsafeWriteView'.
+unsafeLogView :: X ()
+unsafeLogView = do
+  i <- asks internal
+  withWindowSet (io . unsafeWriteView i)

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -34,6 +34,7 @@ import Data.Monoid (getAll)
 import Graphics.X11.Xlib hiding (refreshKeyboardMapping)
 import Graphics.X11.Xlib.Extras
 
+import XMonad.Internal.Core (unsafeMakeInternal)
 import XMonad.Core
 import qualified XMonad.Config as Default
 import XMonad.StackSet (new, floating, member)
@@ -192,7 +193,9 @@ launch initxmc drs = do
         initialWinset = let padToLen n xs = take (max n (length xs)) $ xs ++ repeat ""
             in new layout (padToLen (length xinesc) (workspaces xmc)) $ map SD xinesc
 
-        cf = XConf
+    int <- unsafeMakeInternal initialWinset
+
+    let cf = XConf
             { display       = dpy
             , config        = xmc
             , theRoot       = rootw
@@ -204,6 +207,7 @@ launch initxmc drs = do
             , mousePosition = Nothing
             , currentEvent  = Nothing
             , directories   = drs
+            , internal      = int
             }
 
         st = XState

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -64,6 +64,8 @@ library
                    XMonad.Operations
                    XMonad.StackSet
   other-modules:   Paths_xmonad
+                   XMonad.Internal.Core
+                   XMonad.Internal.Operations
   hs-source-dirs:  src
   build-depends:   base                  >= 4.11 && < 5
                  , X11                   >= 1.10 && < 1.11

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -25,7 +25,8 @@ author:             Spencer Janssen, Don Stewart, Adam Vogt, David Roundy, Jason
                     Jens Petersen, Joey Hess, Jonne Ransijn, Josh Holland, Khudyakov Alexey,
                     Klaus Weidner, Michael G. Sloan, Mikkel Christiansen, Nicolas Dudebout,
                     Ondřej Súkup, Paul Hebble, Shachaf Ben-Kiki, Siim Põder, Tim McIver,
-                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman
+                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman,
+                    L. S. Leary
 maintainer:         xmonad@haskell.org
 tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.3
 category:           System


### PR DESCRIPTION
### Description

#### Summary

Create a layer of indirection between *needing* a refresh and *performing* one, such that no more than one refresh is performed per event handled. This is implemented by extending the X monad to write a "dirty bit". The change improves not only efficiency and UX, but also code reuse and elegance.

#### Commits

##### Track Model–View Deviation in the X monad

> Currently, composability of X actions is broken, or at least flawed.
> The culprits are `windows` and a misplacement of responsibility.

> Every operation that needs to make changes to visible parts of the
> windowset must run them through the core model-rendering function,
> yet when time comes to compose those operations, there's no way to
> prevent intermediate states from being rendered. All of these additional
> renders are potentially expensive or otherwise deleterious to user
> experience; they can map and unmap windows, resize them multiple times,
> wake sleeping or swapped processes, etc. This can easily result in major
> slowdowns and visible artefacts such as windows jumping around,
> workspaces flashing past or borders flickering.

> The original design mitigated these issues by having `windows` accept
> composable windowset-modifying functions, however, this approach only
> works within the scope of a given action; it doesn't help to fuse
> unrelated actions. Further, interleaving any kind of layout operation or
> IO fundamentally breaks the paradigm.

> Some efforts have been made to remedy the problem at the contrib level;
> `X.A.MessageFeedback` and `X.U.PureX` in particular. However, they
> cannot be considered successful: they require actions to be rewritten
> in their paradigm, and must foist the task of transforming composable
> actions into "complete" ones onto the end user. This is not the
> righteous way.

> If we instead recognise that rendering the view is the responsibility of
> the core, a real solution becomes clear: we must take `windows` back
> from both the hands of the end user and the contrib module implementor.
> The way to do so transparently is to replace `windows` with a function
> that, rather than *performing* a refresh, merely *requests* one.

> In the paradigm of `X.U.PureX`, this is achieved by combining actions
> that produce `Any`, however, this approach does not suffice for our end:
> it breaks code by changing types, it forces changes in implementation to
> manually combine the `Any`s, and it interferes with actual return
> values. The proper tool to issue and combine monoidal values in a
> monadic context is the writer monad, hence we extend the X monad to
> write `Any`.

##### MVDT: Propagate changes through Operations and Main

> `refresh` becomes our deviation-declaring, refresh-requesting operation,
> and its pair `norefresh` is introduced to deny such requests or mark
> them handled.

> As promised, we now make `windows` internal by renaming it `render`,
> providing a replacement that just modifies the windowset and issues
> `refresh`.

> `windowBracket` is cannibalised to become `handleRefresh`, catching
> requests and handling them through `render`. As with `windows`,
> we provide a replacement with the corresponding semantics under the
> new ways.

> Finally, we run the event handler and startup operations inside
> `handleRefresh`, completing the change of regime.

> *Note that this change will break any functionality actually requiring
> `windows` to perform an immediate refresh.*

> The solution would be to wrap any such use of `windows` in
> `handleRefresh`, but it currently offers poor support for nesting.
> This matter will be rectified in a later commit.

##### MVDT: Declare every deviation; deprecate the undeclaring

> Under the new regime, an operation should issue `refresh` if it may
> directly cause the model to deviate from the view, and should avoid
> doing so when it knows it will not. Hence:

>  * `updateLayout` issues `refresh` iff the target workspace is visible.
>    For reusability, this workspace-updating logic is implemented as the
>    more general `respace`.

>  * `modifyWindowSet` is deprecated.

>  * `sendMessageWithNoRefresh` is replaced by `messageWorkspace` and
>    deprecated.

>  * `broadcastMessage` may now (indirectly) issue `refresh`.

> `windowBracket` and co. were originally introduced so that windowset
> changes made in `sendMessage` would be properly handled in the
> accompanying refresh. The approach has since been adopted for use in
> `handleRefresh`, so these functions are no longer necessary and don't
> belong in the core. As such, `sendMessage` is simplified and the
> "bracket" functions are deprecated.

##### Clean up `sendMessage`, `setLayout` & `manage`

> There was unnecessary noise and duplication in these functions.

>   * `sendMessage`: Rewrite via `messageWorkspace`

>   * `setLayout`: Rewrite via `sendMessage` and `updateLayout`

>   * `manage`: Remove code equivalent to `W.view (W.currentTag ws) ws`

> The `sendMessage` rewrite also fixes a corner case misbehaviour:
> previously, if message handling resulted in another workspace taking
> focus, the layout update would mangle that workspace. This is no longer
> the case.

##### Support nesting of `handleRefresh`

> `render` requires the previously rendered state of the model—the
> current state of the view—to judge changes against.

> Originally, this was done by taking the windowset for that state and
> requiring changes be provided in the form of a function. Under that
> regime, the windowset is not a fine grained internal model—its
> merely a log of the view which shouldn't be exposed for editing
> outside of `render`.

> `handleRefresh` (previously `windowBracket`) used a cute trick to buy
> granularity within a child action by grabbing the "old" and the "new"
> copies of the windowset that `render` needs before and after the
> action runs. However, such a trick has its limits. In particular, it
> does not support nesting—a refresh in the child action invalidates
> the "old" copy.

> The solution is straightforward: separately from our model, keep an
> actual log of the state of the view, and don't expose it for editing.
> Hence it does not appear in the `XState`, but is secreted away in an
> `IORef` in a new opaque `Internal` portion of the `XConf`.

##### Document MVDT changes; declare authorship

#### Commentary

  - I don't know if there's established MVC jargon for this strategy, so I'm just calling it MVD and MVDT. **Edit**: Other possible names are *dirty* and *dirtying*.

  - I've been building my config on top of (some incarnation of) these changes for several months now, if not a year—they're well tested. The only exceptions are a few brand new changes to the *Declare every deviation* commit:

      - Erased an erroneous `norefresh` from the definition of `broadcastMessage`. It should perhaps be `norefresh`ed at certain usage sites instead.

      - Wrote `respace`, in terms of which `updateLayout` was rewritten.

  - Non-CPS `Writer`/`RWS` is controversial due to possible space leakage, but it does not seem to be an issue here; I don't think I've ever seen xmonad using more than 0.4% of my meagre 8GB RAM. We can eventually swap in the CPS version just to be sure, but to do so now would constrain our dependencies too much.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: they function as expected.

  - [x] I updated the `CHANGES.md` file