### PR TITLE
Relocate the log hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,28 @@
 
 ### Breaking Changes
 
+* MVDT:
+
+    * The type of `runX` has changed.
+
+    * `windows` no longer performs an immediate refresh, but requests one.
+      That request is handled by `handleRefresh`.
+
+    * Deprecated `modifyWindowSet`, `windowBracket`, `windowBracket_` and
+      `sendMessageWithNoRefresh`.
+
+    * Extended `XConf` with a new `internal` field.
+
 * Dropped support for GHC 8.4.
 
 ### Enhancements
+
+* MVDT:
+
+    * X actions can now be combined without performing spurious refreshes.
+
+    * New operations: `norefresh`, `handleRefresh`, `respace`,
+      `messageWorkspace` and `rendered`.
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
     * Extended `XConf` with a new `internal` field.
 
+    * The log hook now runs *before* the layout and other refresh IO.
+
 * Dropped support for GHC 8.4.
 
 ### Enhancements
@@ -26,6 +28,10 @@
 
     * New operations: `norefresh`, `handleRefresh`, `respace`,
       `messageWorkspace` and `rendered`.
+
+    * The log hook may now make changes to the windowset and have those changes
+      handled seamlessly by the accompanying refresh, at no risk of infinite
+      recursion.
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
 

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -39,6 +39,7 @@ module XMonad.Core (
     ManageHook, Query(..), runQuery, Directories'(..), Directories, getDirectories,
   ) where
 
+import XMonad.Internal.Core (Internal)
 import XMonad.StackSet hiding (modify)
 
 import Prelude
@@ -106,6 +107,7 @@ data XConf = XConf
                                       -- the event currently being processed
     , currentEvent :: !(Maybe Event)  -- ^ event currently being processed
     , directories  :: !Directories    -- ^ directories to use
+    , internal     :: !(Internal WindowSet) -- ^ a hiding place for internals
     }
 
 -- todo, better name

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -47,10 +47,9 @@ import qualified Control.Exception as E
 import Control.Applicative ((<|>), empty)
 import Control.Monad.Fail
 import Control.Monad.Fix (fix)
-import Control.Monad.State
+import Control.Monad.RWS
 import Control.Monad.Reader
 import Control.Monad (filterM, guard, void, when)
-import Data.Semigroup
 import Data.Traversable (for)
 import Data.Time.Clock (UTCTime)
 import Data.Default.Class
@@ -157,16 +156,19 @@ newtype ScreenDetail = SD { screenRect :: Rectangle }
 
 ------------------------------------------------------------------------
 
--- | The X monad, 'ReaderT' and 'StateT' transformers over 'IO'
--- encapsulating the window manager configuration and state,
--- respectively.
+-- | The X monad; 'RWST' transformer over 'IO' encapsulating the window manager
+-- configuration, model--view deviation and state, respectively.
 --
--- Dynamic components may be retrieved with 'get', static components
--- with 'ask'. With newtype deriving we get readers and state monads
--- instantiated on 'XConf' and 'XState' automatically.
+-- Dynamic components may be retrieved with 'get' and 'listen', static
+-- components with 'ask'. With newtype deriving we get readers, writers and
+-- state monads instantiated on 'XConf', 'Any' and 'XState' automatically.
 --
-newtype X a = X (ReaderT XConf (StateT XState IO) a)
-    deriving (Functor, Applicative, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf)
+newtype X a = X (RWST XConf Any XState IO a)
+    deriving
+      ( Functor, Applicative, Monad, MonadFail, MonadIO
+      , MonadReader XConf, MonadWriter Any, MonadState XState
+      , MonadRWS XConf Any XState
+      )
     deriving (Semigroup, Monoid) via Ap X a
 
 instance Default a => Default (X a) where
@@ -184,9 +186,9 @@ instance Default a => Default (Query a) where
     def = return def
 
 -- | Run the 'X' monad, given a chunk of 'X' monad code, and an initial state
--- Return the result, and final state
-runX :: XConf -> XState -> X a -> IO (a, XState)
-runX c st (X a) = runStateT (runReaderT a c) st
+-- Return the result, final state and model--view deviation.
+runX :: XConf -> XState -> X a -> IO (a, XState, Any)
+runX c st (X rwsa) = runRWST rwsa c st
 
 -- | Run in the 'X' monad, and in case of exception, and catch it and log it
 -- to stderr, and run the error case.
@@ -194,9 +196,10 @@ catchX :: X a -> X a -> X a
 catchX job errcase = do
     st <- get
     c <- ask
-    (a, s') <- io $ runX c st job `E.catch` \e -> case fromException e of
+    (a, s', mvd) <- io $ runX c st job `E.catch` \e -> case fromException e of
                         Just (_ :: ExitCode) -> throw e
                         _ -> do hPrint stderr e; runX c st errcase
+    tell mvd
     put s'
     return a
 

--- a/src/XMonad/Internal/Core.hs
+++ b/src/XMonad/Internal/Core.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module XMonad.Internal.Core
+  ( Internal, unsafeMakeInternal
+  , readView, unsafeWriteView
+  ) where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+
+-- | An opaque data type for holding state and configuration that isn't to be
+--   laid bare to the world outside, nor even to the rest of the package if we
+--   can help it.
+newtype Internal model = Internal
+  { view :: IORef model -- ^ An 'IORef' to which we log the state of the view.
+  }
+
+-- | The ability to construct an 'Internal' allows one to play tricks with
+--   'local'.
+unsafeMakeInternal :: model -> IO (Internal model)
+unsafeMakeInternal model = do
+  viewRef <- newIORef model
+  pure Internal
+    { view = viewRef
+    }
+
+readView :: Internal model -> IO model
+readView Internal{view} = readIORef view
+
+-- | The 'view' ref can only be safely written to with a just-rendered model.
+unsafeWriteView :: Internal model -> model -> IO ()
+unsafeWriteView Internal{view} = writeIORef view
+

--- a/src/XMonad/Internal/Operations.hs
+++ b/src/XMonad/Internal/Operations.hs
@@ -1,0 +1,18 @@
+
+module XMonad.Internal.Operations
+  ( rendered, unsafeLogView
+  ) where
+
+import Control.Monad.Reader (asks)
+import XMonad.Internal.Core (readView, unsafeWriteView)
+import XMonad.Core (X, WindowSet, internal, io, withWindowSet)
+
+-- | Examine the 'WindowSet' that's currently rendered.
+rendered :: X WindowSet
+rendered = asks internal >>= io . readView
+
+-- | See 'unsafeWriteView'.
+unsafeLogView :: X ()
+unsafeLogView = do
+  i <- asks internal
+  withWindowSet (io . unsafeWriteView i)

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -34,6 +34,7 @@ import Data.Monoid (getAll)
 import Graphics.X11.Xlib hiding (refreshKeyboardMapping)
 import Graphics.X11.Xlib.Extras
 
+import XMonad.Internal.Core (unsafeMakeInternal)
 import XMonad.Core
 import qualified XMonad.Config as Default
 import XMonad.StackSet (new, floating, member)
@@ -192,7 +193,9 @@ launch initxmc drs = do
         initialWinset = let padToLen n xs = take (max n (length xs)) $ xs ++ repeat ""
             in new layout (padToLen (length xinesc) (workspaces xmc)) $ map SD xinesc
 
-        cf = XConf
+    int <- unsafeMakeInternal initialWinset
+
+    let cf = XConf
             { display       = dpy
             , config        = xmc
             , theRoot       = rootw
@@ -204,6 +207,7 @@ launch initxmc drs = do
             , mousePosition = Nothing
             , currentEvent  = Nothing
             , directories   = drs
+            , internal      = int
             }
 
         st = XState

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -251,7 +251,6 @@ render = withWindowSet \ws -> do
     isMouseFocused <- asks mouseFocused
     unless isMouseFocused $ clearEvents enterWindowMask
     unsafeLogView
-    asks (logHook . config) >>= userCodeDef ()
 
 -- | Modify the @WindowSet@ in state with no special handling.
 {-# DEPRECATED modifyWindowSet "Use `windows` and `norefresh`." #-}
@@ -263,7 +262,10 @@ modifyWindowSet = norefresh . windows
 handleRefresh :: X a -> X a
 handleRefresh action = norefresh do
   (a, Any dev) <- listen action
-  when dev render $> a
+  when dev do
+    asks (logHook . config) >>= userCodeDef ()
+    render
+  pure a
 
 -- | Perform an @X@ action and check its return value against a predicate @p@.
 -- Request a refresh iff @p@ holds.

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -64,6 +64,8 @@ library
                    XMonad.Operations
                    XMonad.StackSet
   other-modules:   Paths_xmonad
+                   XMonad.Internal.Core
+                   XMonad.Internal.Operations
   hs-source-dirs:  src
   build-depends:   base                  >= 4.11 && < 5
                  , X11                   >= 1.10 && < 1.11

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -25,7 +25,8 @@ author:             Spencer Janssen, Don Stewart, Adam Vogt, David Roundy, Jason
                     Jens Petersen, Joey Hess, Jonne Ransijn, Josh Holland, Khudyakov Alexey,
                     Klaus Weidner, Michael G. Sloan, Mikkel Christiansen, Nicolas Dudebout,
                     Ondřej Súkup, Paul Hebble, Shachaf Ben-Kiki, Siim Põder, Tim McIver,
-                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman
+                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman,
+                    L. S. Leary
 maintainer:         xmonad@haskell.org
 tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.3
 category:           System


### PR DESCRIPTION
### Description

Based on `mvdt`/#432.

#### Commits

##### Shift the `logHook` into `handleRefresh` before `render`

> Using `handleRefresh` as we are, a longstanding issue with the `logHook`
> is fixed, or rather, transformed: running `windows` within it will not
> cause an infinite loop; any requests it issues are silently discarded.
> That, however, is not ideal either: unhandled changes may be introduced
> to the windowset.

> We could run the `logHook` via `handleRefresh`, but that would put us
> back where we started with infinite loops. Alternatively, we could treat
> a request in the `logHook` as an error and discard its changes à la
> `catchX`.

> However, the way that gives the best bang for buck is to move the
> `logHook` from `render` into `handleRefresh`, after the user effects
> have run but before the refresh itself. Like this, any changes it makes
> are seamlessly handled in the refresh it accompanies. This is simple,
> efficient, and best of all: it transforms a mere `logHook` into a fully
> fledged "refreshHook".

> While the `logHook` is seeing essentially the same state as far as the
> internal model goes, there's one key observable difference: it runs
> before the effects in `render`, and thus it does not see any changes
> that might result from running the layout. This could break some
> existing usage.

#### Commentary

  - This has also been tested on my system for some months with no issues, but it may break contrib modules I don't use.

  - Defeats the delay-to-`logHook` strategy used to set window properties in the `manageHook`. A remedy is provided in a followup PR.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: they function as intended.

  - [x] I updated the `CHANGES.md` file
