### PR TITLE
Simplify the design of the manage hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,28 @@
 
 ### Breaking Changes
 
+* MVDT:
+
+    * The type of `runX` has changed.
+
+    * `windows` no longer performs an immediate refresh, but requests one.
+      That request is handled by `handleRefresh`.
+
+    * Deprecated `modifyWindowSet`, `windowBracket`, `windowBracket_` and
+      `sendMessageWithNoRefresh`.
+
+    * Extended `XConf` with a new `internal` field.
+
 * Dropped support for GHC 8.4.
 
 ### Enhancements
+
+* MVDT:
+
+    * X actions can now be combined without performing spurious refreshes.
+
+    * New operations: `norefresh`, `handleRefresh`, `respace`,
+      `messageWorkspace` and `rendered`.
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,29 @@
 
     * Extended `XConf` with a new `internal` field.
 
+    * The definition of the `ManageHook` type synonym has changed.
+
+    * The order of manage hook composition has been reversed, though the order
+      in which matching and `liftX` actions are performed has not.
+
+        As such, e.g.
+
+        ```haskell
+        manageHook = composeAll
+          [ test1 --> doSomething <> liftX someAction >> idHook
+          , test2 --> doThird <> doSecond <> doFirst
+          ]
+        ```
+
+        should be corrected to
+
+        ```haskell
+        manageHook = composeAll
+          [ test1 --> doSomething <> liftX someAction >> idHook
+          , test2 --> doFirst <> doSecond <> doThird
+          ]
+        ```
+
 * Dropped support for GHC 8.4.
 
 ### Enhancements
@@ -26,6 +49,30 @@
 
     * New operations: `norefresh`, `handleRefresh`, `respace`,
       `messageWorkspace` and `rendered`.
+
+    * `ManageHook` supports new syntax.
+
+        Instead of, e.g.
+
+        ```haskell
+        manageHook = composeAll
+          [ test1 --> fooHook
+          , test2 --> barQueryAction >> idHook
+          , test3 --> fooHook <> bazHook <> quuxHook
+          ]
+        ```
+
+        you can now write
+
+        ```haskell
+        manageHook = do
+          test1 --> fooHook
+          test2 --> barQueryAction
+          test3 --> do
+            fooHook
+            bazHook
+            quuxHook
+        ```
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
 

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -39,6 +39,7 @@ module XMonad.Core (
     ManageHook, Query(..), runQuery, Directories'(..), Directories, getDirectories,
   ) where
 
+import XMonad.Internal.Core (Internal)
 import XMonad.StackSet hiding (modify)
 
 import Prelude
@@ -106,6 +107,7 @@ data XConf = XConf
                                       -- the event currently being processed
     , currentEvent :: !(Maybe Event)  -- ^ event currently being processed
     , directories  :: !Directories    -- ^ directories to use
+    , internal     :: !(Internal WindowSet) -- ^ a hiding place for internals
     }
 
 -- todo, better name

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -176,7 +176,7 @@ newtype X a = X (RWST XConf Any XState IO a)
 instance Default a => Default (X a) where
     def = return def
 
-type ManageHook = Query (Endo WindowSet)
+type ManageHook = Query ()
 newtype Query a = Query (ReaderT Window X a)
     deriving (Functor, Applicative, Monad, MonadReader Window, MonadIO)
     deriving (Semigroup, Monoid) via Ap Query a

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -47,10 +47,9 @@ import qualified Control.Exception as E
 import Control.Applicative ((<|>), empty)
 import Control.Monad.Fail
 import Control.Monad.Fix (fix)
-import Control.Monad.State
+import Control.Monad.RWS
 import Control.Monad.Reader
 import Control.Monad (filterM, guard, void, when)
-import Data.Semigroup
 import Data.Traversable (for)
 import Data.Time.Clock (UTCTime)
 import Data.Default.Class
@@ -157,16 +156,19 @@ newtype ScreenDetail = SD { screenRect :: Rectangle }
 
 ------------------------------------------------------------------------
 
--- | The X monad, 'ReaderT' and 'StateT' transformers over 'IO'
--- encapsulating the window manager configuration and state,
--- respectively.
+-- | The X monad; 'RWST' transformer over 'IO' encapsulating the window manager
+-- configuration, model--view deviation and state, respectively.
 --
--- Dynamic components may be retrieved with 'get', static components
--- with 'ask'. With newtype deriving we get readers and state monads
--- instantiated on 'XConf' and 'XState' automatically.
+-- Dynamic components may be retrieved with 'get' and 'listen', static
+-- components with 'ask'. With newtype deriving we get readers, writers and
+-- state monads instantiated on 'XConf', 'Any' and 'XState' automatically.
 --
-newtype X a = X (ReaderT XConf (StateT XState IO) a)
-    deriving (Functor, Applicative, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf)
+newtype X a = X (RWST XConf Any XState IO a)
+    deriving
+      ( Functor, Applicative, Monad, MonadFail, MonadIO
+      , MonadReader XConf, MonadWriter Any, MonadState XState
+      , MonadRWS XConf Any XState
+      )
     deriving (Semigroup, Monoid) via Ap X a
 
 instance Default a => Default (X a) where
@@ -184,9 +186,9 @@ instance Default a => Default (Query a) where
     def = return def
 
 -- | Run the 'X' monad, given a chunk of 'X' monad code, and an initial state
--- Return the result, and final state
-runX :: XConf -> XState -> X a -> IO (a, XState)
-runX c st (X a) = runStateT (runReaderT a c) st
+-- Return the result, final state and model--view deviation.
+runX :: XConf -> XState -> X a -> IO (a, XState, Any)
+runX c st (X rwsa) = runRWST rwsa c st
 
 -- | Run in the 'X' monad, and in case of exception, and catch it and log it
 -- to stderr, and run the error case.
@@ -194,9 +196,10 @@ catchX :: X a -> X a -> X a
 catchX job errcase = do
     st <- get
     c <- ask
-    (a, s') <- io $ runX c st job `E.catch` \e -> case fromException e of
+    (a, s', mvd) <- io $ runX c st job `E.catch` \e -> case fromException e of
                         Just (_ :: ExitCode) -> throw e
                         _ -> do hPrint stderr e; runX c st errcase
+    tell mvd
     put s'
     return a
 

--- a/src/XMonad/Internal/Core.hs
+++ b/src/XMonad/Internal/Core.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module XMonad.Internal.Core
+  ( Internal, unsafeMakeInternal
+  , readView, unsafeWriteView
+  ) where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+
+-- | An opaque data type for holding state and configuration that isn't to be
+--   laid bare to the world outside, nor even to the rest of the package if we
+--   can help it.
+newtype Internal model = Internal
+  { view :: IORef model -- ^ An 'IORef' to which we log the state of the view.
+  }
+
+-- | The ability to construct an 'Internal' allows one to play tricks with
+--   'local'.
+unsafeMakeInternal :: model -> IO (Internal model)
+unsafeMakeInternal model = do
+  viewRef <- newIORef model
+  pure Internal
+    { view = viewRef
+    }
+
+readView :: Internal model -> IO model
+readView Internal{view} = readIORef view
+
+-- | The 'view' ref can only be safely written to with a just-rendered model.
+unsafeWriteView :: Internal model -> model -> IO ()
+unsafeWriteView Internal{view} = writeIORef view
+

--- a/src/XMonad/Internal/Operations.hs
+++ b/src/XMonad/Internal/Operations.hs
@@ -1,0 +1,18 @@
+
+module XMonad.Internal.Operations
+  ( rendered, unsafeLogView
+  ) where
+
+import Control.Monad.Reader (asks)
+import XMonad.Internal.Core (readView, unsafeWriteView)
+import XMonad.Core (X, WindowSet, internal, io, withWindowSet)
+
+-- | Examine the 'WindowSet' that's currently rendered.
+rendered :: X WindowSet
+rendered = asks internal >>= io . readView
+
+-- | See 'unsafeWriteView'.
+unsafeLogView :: X ()
+unsafeLogView = do
+  i <- asks internal
+  withWindowSet (io . unsafeWriteView i)

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -34,6 +34,7 @@ import Data.Monoid (getAll)
 import Graphics.X11.Xlib hiding (refreshKeyboardMapping)
 import Graphics.X11.Xlib.Extras
 
+import XMonad.Internal.Core (unsafeMakeInternal)
 import XMonad.Core
 import qualified XMonad.Config as Default
 import XMonad.StackSet (new, floating, member)
@@ -192,7 +193,9 @@ launch initxmc drs = do
         initialWinset = let padToLen n xs = take (max n (length xs)) $ xs ++ repeat ""
             in new layout (padToLen (length xinesc) (workspaces xmc)) $ map SD xinesc
 
-        cf = XConf
+    int <- unsafeMakeInternal initialWinset
+
+    let cf = XConf
             { display       = dpy
             , config        = xmc
             , theRoot       = rootw
@@ -204,6 +207,7 @@ launch initxmc drs = do
             , mousePosition = Nothing
             , currentEvent  = Nothing
             , directories   = drs
+            , internal      = int
             }
 
         st = XState

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -21,10 +21,12 @@ import Graphics.X11.Xlib (Display, Window, internAtom, wM_NAME)
 import Control.Exception (bracket, SomeException(..))
 import qualified Control.Exception as E
 import Control.Monad.Reader
+import Control.Monad.State
 import Data.Maybe
-import Data.Monoid
+import qualified Data.Map as M
 import qualified XMonad.StackSet as W
-import XMonad.Operations (floatLocation, reveal, isFixedSizeOrTransient)
+import XMonad.Operations
+  (floatLocation, reveal, isFixedSizeOrTransient, windows)
 
 -- | Lift an 'X' action to a 'Query'.
 liftX :: X a -> Query a
@@ -106,12 +108,17 @@ getStringProperty d w p = do
   return $ fmap (map (toEnum . fromIntegral)) md
 
 -- | Return whether the window will be a floating window or not
+{-# DEPRECATED willFloat "Use isFloat." #-}
 willFloat :: Query Bool
 willFloat = ask >>= \w -> liftX $ withDisplay $ \d -> isFixedSizeOrTransient d w
 
+-- | Return whether the window is a floating window or not
+isFloat :: Query Bool
+isFloat = ask >>= \w -> liftX $ gets (M.member w . W.floating . windowset)
+
 -- | Modify the 'WindowSet' with a pure function.
-doF :: (s -> s) -> Query (Endo s)
-doF = return . Endo
+doF :: (WindowSet -> WindowSet) -> ManageHook
+doF = liftX . windows
 
 -- | Move the window to the floating layer.
 doFloat :: ManageHook

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -66,7 +66,7 @@ import qualified XMonad.StackSet as W
 import XMonad.Internal.Operations (rendered, unsafeLogView)
 
 import Data.Maybe
-import Data.Monoid          (Endo(..),Any(..))
+import Data.Monoid          (Any(..))
 import Data.List            (nub, (\\), find)
 import Data.Bits            ((.|.), (.&.), complement, setBit, testBit)
 import Data.Function        (on)
@@ -123,10 +123,10 @@ manage w = whenX (not <$> isClient w) $ withDisplay $ \d -> do
 
         f | shouldFloat = W.float w (adjust rr)
           | otherwise   = id
+    windows (f . W.insertUp w)
 
     mh <- asks (manageHook . config)
-    g <- appEndo <$> userCodeDef (Endo id) (runQuery mh w)
-    windows (g . f . W.insertUp w)
+    userCodeDef () (runQuery mh w)
 
 -- | A window no longer exists; remove it from the window
 -- list, on whatever workspace it is.

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -64,6 +64,8 @@ library
                    XMonad.Operations
                    XMonad.StackSet
   other-modules:   Paths_xmonad
+                   XMonad.Internal.Core
+                   XMonad.Internal.Operations
   hs-source-dirs:  src
   build-depends:   base                  >= 4.11 && < 5
                  , X11                   >= 1.10 && < 1.11

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -25,7 +25,8 @@ author:             Spencer Janssen, Don Stewart, Adam Vogt, David Roundy, Jason
                     Jens Petersen, Joey Hess, Jonne Ransijn, Josh Holland, Khudyakov Alexey,
                     Klaus Weidner, Michael G. Sloan, Mikkel Christiansen, Nicolas Dudebout,
                     Ondřej Súkup, Paul Hebble, Shachaf Ben-Kiki, Siim Põder, Tim McIver,
-                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman
+                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman,
+                    L. S. Leary
 maintainer:         xmonad@haskell.org
 tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.3
 category:           System


### PR DESCRIPTION
### Description

Based on `mvdt`/#432.

#### Commits

##### MVDT: Simplify the design of the manage hook

> `ManageHook` as `Query (Endo WindowSet)` is a holdover from The Old Way.

> `Query` wraps the `X` Monad, which already collects and composes changes
> to the windowset. As such, the `Endo WindowSet` is redundant. Worse, the
> way these changes compose is not at all obvious or intuitive.

> Suppose you compose two ManageHook values:

> ```haskell
> manageHook = (qF $> Endo f)
>           <> (qG $> Endo g)
> ```

> The result of running the `manageHook` on some `w` is not, as one might
> guess,

> ```haskell
> do
>   runQuery qF w
>   windows f
>   runQuery qG w
>   windows g
> ```

> nor is it

> ```haskell
> do
>   runQuery qF w
>   runQuery qG w
>   windows f
>   windows g
> ```

> Unfortunately, it is:

> ```haskell
> do
>   runQuery qF w
>   runQuery qG w
>   windows g
>   windows f
> ```

> This is a wart, and it's one we can now excise.

> Hence the `ManageHook` type synonym is simplified to `Query ()`, and
> `manage` runs the hook as-is. It also performs the initial handling of
> the window beforehand, so it's fully visible within the hook. As such,
> `willFloat` (which repeats the indirect logic in `manage`) is deprecated
> in favour of `isFloat`, which directly references the model.

> Note that this change also allows cleaner syntax in configuration. E.g.

> ```haskell
> manageHook = composeAll
>   [ test1 --> fooHook
>   , test2 --> barQueryAction >> idHook
>   , test3 --> fooHook <> bazHook <> quuxHook
>   ]
> ```

> can become

> ```haskell
> manageHook = do
>   test1 --> fooHook
>   test2 --> barQueryAction
>   test3 --> do
>     fooHook
>     bazHook
>     quuxHook
> ```

> To accomodate the change, `doF` must become a lifted `windows`, but that
> and monoid-polymorphism take care of adjusting the rest of the core
> interface transparently.

> As such, simple configs will continue to compile, but extensions that
> directly interfered with the old `Endo WindowSet` won't.

> Further, due to `doF`s now composing forwards rather than backwards,
> many user configs will break silently. The solution is to reverse the
> order that `doF`, `doFloat`, `doIgnore` and `doShift` appear in,
> extending that list to include anything else built on `doF`, like
> `doShiftTo` or `doFullFloat` from `X.H.ManageHelpers`.

#### Commentary

  - An early incarnation of these changes was tested for some months.

  - Unlike the other PRs, I'm not actually sure this one is advisable. It may be "morally correct", but the degree of config breakage may just be too high for it to be worth it.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: they function as intended.

  - [x] I updated the `CHANGES.md` file
