### PR TITLE
Purify the unclean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,28 @@
 
 ### Breaking Changes
 
+* MVDT:
+
+    * The type of `runX` has changed.
+
+    * `windows` no longer performs an immediate refresh, but requests one.
+      That request is handled by `handleRefresh`.
+
+    * Deprecated `modifyWindowSet`, `windowBracket`, `windowBracket_` and
+      `sendMessageWithNoRefresh`.
+
+    * Extended `XConf` with a new `internal` field.
+
 * Dropped support for GHC 8.4.
 
 ### Enhancements
+
+* MVDT:
+
+    * X actions can now be combined without performing spurious refreshes.
+
+    * New operations: `norefresh`, `handleRefresh`, `respace`,
+      `messageWorkspace` and `rendered`.
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+* Deprecated `runOnWorkspaces`.
+
 * MVDT:
 
     * The type of `runX` has changed.
@@ -27,6 +29,8 @@
 * Dropped support for GHC 8.4.
 
 ### Enhancements
+
+* X.StackSet now provides `mapWorkspaces` and `traverseWorkspaces`.
 
 * MVDT:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,14 @@
 
     * Extended `XConf` with a new `internal` field.
 
+    * Newly generalised functions mean that bindings which previously type
+      checked without a signature may now require a pragma at the head of
+      `xmonad.hs` to do so.
+
+        ```haskell
+        {-# LANGUAGE FlexibleContexts #-}
+        ```
+
 * Dropped support for GHC 8.4.
 
 ### Enhancements
@@ -26,6 +34,8 @@
 
     * New operations: `norefresh`, `handleRefresh`, `respace`,
       `messageWorkspace` and `rendered`.
+
+    * Various operations have been generalised and are now pure.
 
 * Exported `sendRestart` and `sendReplace` from `XMonad.Operations`.
 

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -39,6 +39,7 @@ module XMonad.Core (
     ManageHook, Query(..), runQuery, Directories'(..), Directories, getDirectories,
   ) where
 
+import XMonad.Internal.Core (Internal)
 import XMonad.StackSet hiding (modify)
 
 import Prelude
@@ -106,6 +107,7 @@ data XConf = XConf
                                       -- the event currently being processed
     , currentEvent :: !(Maybe Event)  -- ^ event currently being processed
     , directories  :: !Directories    -- ^ directories to use
+    , internal     :: !(Internal WindowSet) -- ^ a hiding place for internals
     }
 
 -- todo, better name

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE BlockArguments #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -473,13 +474,11 @@ xmessage msg = void . xfork $ do
 
 -- | This is basically a map function, running a function in the 'X' monad on
 -- each workspace with the output of that function being the modified workspace.
+{-# DEPRECATED runOnWorkspaces "Use `traverseWorkspaces`." #-}
 runOnWorkspaces :: MonadState XState m => (WindowSpace -> m WindowSpace) -> m ()
-runOnWorkspaces job = do
-    ws <- gets windowset
-    h <- mapM job $ hidden ws
-    ~(c:v) <- mapM (\s -> (\w -> s { workspace = w}) <$> job (workspace s))
-             $ current ws : visible ws
-    modify $ \s -> s { windowset = ws { current = c, visible = v, hidden = h } }
+runOnWorkspaces job = withWindowSet \ws -> do
+  ws' <- traverseWorkspaces job ws
+  modify \st -> st{ windowset = ws' }
 
 -- | All the directories that xmonad will use.  They will be used for
 -- the following purposes:

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -47,10 +47,9 @@ import qualified Control.Exception as E
 import Control.Applicative ((<|>), empty)
 import Control.Monad.Fail
 import Control.Monad.Fix (fix)
-import Control.Monad.State
+import Control.Monad.RWS
 import Control.Monad.Reader
 import Control.Monad (filterM, guard, void, when)
-import Data.Semigroup
 import Data.Traversable (for)
 import Data.Time.Clock (UTCTime)
 import Data.Default.Class
@@ -157,16 +156,19 @@ newtype ScreenDetail = SD { screenRect :: Rectangle }
 
 ------------------------------------------------------------------------
 
--- | The X monad, 'ReaderT' and 'StateT' transformers over 'IO'
--- encapsulating the window manager configuration and state,
--- respectively.
+-- | The X monad; 'RWST' transformer over 'IO' encapsulating the window manager
+-- configuration, model--view deviation and state, respectively.
 --
--- Dynamic components may be retrieved with 'get', static components
--- with 'ask'. With newtype deriving we get readers and state monads
--- instantiated on 'XConf' and 'XState' automatically.
+-- Dynamic components may be retrieved with 'get' and 'listen', static
+-- components with 'ask'. With newtype deriving we get readers, writers and
+-- state monads instantiated on 'XConf', 'Any' and 'XState' automatically.
 --
-newtype X a = X (ReaderT XConf (StateT XState IO) a)
-    deriving (Functor, Applicative, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf)
+newtype X a = X (RWST XConf Any XState IO a)
+    deriving
+      ( Functor, Applicative, Monad, MonadFail, MonadIO
+      , MonadReader XConf, MonadWriter Any, MonadState XState
+      , MonadRWS XConf Any XState
+      )
     deriving (Semigroup, Monoid) via Ap X a
 
 instance Default a => Default (X a) where
@@ -184,9 +186,9 @@ instance Default a => Default (Query a) where
     def = return def
 
 -- | Run the 'X' monad, given a chunk of 'X' monad code, and an initial state
--- Return the result, and final state
-runX :: XConf -> XState -> X a -> IO (a, XState)
-runX c st (X a) = runStateT (runReaderT a c) st
+-- Return the result, final state and model--view deviation.
+runX :: XConf -> XState -> X a -> IO (a, XState, Any)
+runX c st (X rwsa) = runRWST rwsa c st
 
 -- | Run in the 'X' monad, and in case of exception, and catch it and log it
 -- to stderr, and run the error case.
@@ -194,9 +196,10 @@ catchX :: X a -> X a -> X a
 catchX job errcase = do
     st <- get
     c <- ask
-    (a, s') <- io $ runX c st job `E.catch` \e -> case fromException e of
+    (a, s', mvd) <- io $ runX c st job `E.catch` \e -> case fromException e of
                         Just (_ :: ExitCode) -> throw e
                         _ -> do hPrint stderr e; runX c st errcase
+    tell mvd
     put s'
     return a
 

--- a/src/XMonad/Internal/Core.hs
+++ b/src/XMonad/Internal/Core.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module XMonad.Internal.Core
+  ( Internal, unsafeMakeInternal
+  , readView, unsafeWriteView
+  ) where
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+
+-- | An opaque data type for holding state and configuration that isn't to be
+--   laid bare to the world outside, nor even to the rest of the package if we
+--   can help it.
+newtype Internal model = Internal
+  { view :: IORef model -- ^ An 'IORef' to which we log the state of the view.
+  }
+
+-- | The ability to construct an 'Internal' allows one to play tricks with
+--   'local'.
+unsafeMakeInternal :: model -> IO (Internal model)
+unsafeMakeInternal model = do
+  viewRef <- newIORef model
+  pure Internal
+    { view = viewRef
+    }
+
+readView :: Internal model -> IO model
+readView Internal{view} = readIORef view
+
+-- | The 'view' ref can only be safely written to with a just-rendered model.
+unsafeWriteView :: Internal model -> model -> IO ()
+unsafeWriteView Internal{view} = writeIORef view
+

--- a/src/XMonad/Internal/Operations.hs
+++ b/src/XMonad/Internal/Operations.hs
@@ -1,0 +1,18 @@
+
+module XMonad.Internal.Operations
+  ( rendered, unsafeLogView
+  ) where
+
+import Control.Monad.Reader (asks)
+import XMonad.Internal.Core (readView, unsafeWriteView)
+import XMonad.Core (X, WindowSet, internal, io, withWindowSet)
+
+-- | Examine the 'WindowSet' that's currently rendered.
+rendered :: X WindowSet
+rendered = asks internal >>= io . readView
+
+-- | See 'unsafeWriteView'.
+unsafeLogView :: X ()
+unsafeLogView = do
+  i <- asks internal
+  withWindowSet (io . unsafeWriteView i)

--- a/src/XMonad/Main.hs
+++ b/src/XMonad/Main.hs
@@ -34,6 +34,7 @@ import Data.Monoid (getAll)
 import Graphics.X11.Xlib hiding (refreshKeyboardMapping)
 import Graphics.X11.Xlib.Extras
 
+import XMonad.Internal.Core (unsafeMakeInternal)
 import XMonad.Core
 import qualified XMonad.Config as Default
 import XMonad.StackSet (new, floating, member)
@@ -192,7 +193,9 @@ launch initxmc drs = do
         initialWinset = let padToLen n xs = take (max n (length xs)) $ xs ++ repeat ""
             in new layout (padToLen (length xinesc) (workspaces xmc)) $ map SD xinesc
 
-        cf = XConf
+    int <- unsafeMakeInternal initialWinset
+
+    let cf = XConf
             { display       = dpy
             , config        = xmc
             , theRoot       = rootw
@@ -204,6 +207,7 @@ launch initxmc drs = do
             , mousePosition = Nothing
             , currentEvent  = Nothing
             , directories   = drs
+            , internal      = int
             }
 
         st = XState

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -51,7 +51,7 @@ infix 0 -->
 p --> f = p >>= \b -> if b then f else return mempty
 
 -- | @q =? x@. if the result of @q@ equals @x@, return 'True'.
-(=?) :: Eq a => Query a -> a -> Query Bool
+(=?) :: (Functor f, Eq a) => f a -> a -> f Bool
 q =? x = fmap (== x) q
 
 infixr 3 <&&>, <||>

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -171,7 +171,7 @@ respace
   => WorkspaceId -> (WindowSpace -> WindowSpace) -> m ()
 respace i f = do
   visibles <- gets (fmap (W.tag . W.workspace) . W.screens . windowset)
-  runOnWorkspaces \ww -> pure if W.tag ww == i
+  norefresh . windows $ W.mapWorkspaces \ww -> if W.tag ww == i
     then f ww
     else   ww
   when (i `elem` visibles) refresh

--- a/src/XMonad/StackSet.hs
+++ b/src/XMonad/StackSet.hs
@@ -41,6 +41,7 @@ module XMonad.StackSet (
         -- * Modifying the stackset
         -- $modifyStackset
         insertUp, delete, delete', filter,
+        mapWorkspaces, traverseWorkspaces,
         -- * Setting the master window
         -- $settingMW
         swapUp, swapDown, swapMaster, shiftMaster, modify, modify', float, sink, -- needed by users
@@ -54,6 +55,8 @@ module XMonad.StackSet (
 
 import Prelude hiding (filter)
 import Control.Applicative.Backwards (Backwards (Backwards, forwards))
+import Data.Functor ((<&>))
+import Data.Functor.Identity
 import Data.Foldable (foldr, toList)
 import Data.Maybe   (listToMaybe,isJust,fromMaybe)
 import qualified Data.List as L (deleteBy,find,splitAt,filter,nub)
@@ -516,6 +519,24 @@ delete' w s = s { current = removeFromScreen        (current s)
                 , hidden  = map removeFromWorkspace (hidden  s) }
     where removeFromWorkspace ws = ws { stack = stack ws >>= filter (/=w) }
           removeFromScreen scr   = scr { workspace = removeFromWorkspace (workspace scr) }
+
+-- | Map over the 'Workspace's of a 'StackSet'.
+mapWorkspaces
+  :: (Workspace i l a        -> Workspace i' l' a)
+  ->  StackSet  i l a sid sd -> StackSet  i' l' a sid sd
+mapWorkspaces f = runIdentity . traverseWorkspaces (Identity . f)
+
+-- | 'traverse' the 'Workspace's of a 'StackSet'.
+traverseWorkspaces
+  :: Applicative f
+  => (Workspace i l a        -> f (Workspace i' l' a))
+  ->  StackSet  i l a sid sd -> f (StackSet  i' l' a sid sd)
+traverseWorkspaces f s = StackSet
+  <$>          onScreen (current  s)
+  <*> traverse onScreen (visible  s)
+  <*> traverse f        (hidden   s)
+  <*> pure              (floating s)
+  where onScreen scr = f (workspace scr) <&> \w -> scr{ workspace = w }
 
 ------------------------------------------------------------------------
 

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -64,6 +64,8 @@ library
                    XMonad.Operations
                    XMonad.StackSet
   other-modules:   Paths_xmonad
+                   XMonad.Internal.Core
+                   XMonad.Internal.Operations
   hs-source-dirs:  src
   build-depends:   base                  >= 4.11 && < 5
                  , X11                   >= 1.10 && < 1.11

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -25,7 +25,8 @@ author:             Spencer Janssen, Don Stewart, Adam Vogt, David Roundy, Jason
                     Jens Petersen, Joey Hess, Jonne Ransijn, Josh Holland, Khudyakov Alexey,
                     Klaus Weidner, Michael G. Sloan, Mikkel Christiansen, Nicolas Dudebout,
                     Ondřej Súkup, Paul Hebble, Shachaf Ben-Kiki, Siim Põder, Tim McIver,
-                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman
+                    Trevor Elliott, Wouter Swierstra, Conrad Irwin, Tim Thelion, Tony Zorman,
+                    L. S. Leary
 maintainer:         xmonad@haskell.org
 tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.3
 category:           System


### PR DESCRIPTION
### Description

Based on `mvdt`/#432.

#### Commits

##### Purify the unclean by generalising type signatures

> Many operations were previously impure due to direct or indirect use of
> the old `windows`, now `render`. Due to MVDT, we can now purify them.

> To do so, we generalise their type signatures away from `X` to
> arbitrary monads satisfying the relevant mtl constraints. This has
> further advantages in terms of code reuse (e.g. in `X.U.PureX`) and
> possibly in testing.

> However, it also causes some breakage—bindings that previously type
> checked without a signature may now need `FlexibleContexts` to do so.

##### Deprecate `runOnWorkspaces` in favour of `traverseWorkspaces`

> `runOnWorkspaces` was a questionable existence in various ways:

>   * It traversed the workspaces in a unexpected, nonstandard order.

>   * It needlessly utilised a non-exhaustive pattern match, abusing
>     first `MonadFail` then irrefutability to evade warning.

>   * It was used nowhere in contrib, once in core—that sole use with a
>     pure function.

>   * Even after generalisation, it still has a bad type, both misleading and
>     lacking in parametricity. Specialising the `StackSet` traversal to the
>     `WindowSet` in `XState` gives the function too much power, and suggests
>     that it's using that power to provide special support for `WindowSet`
>     modifications when in fact it does no such thing.

> To resolve these issues, the workspace traversal logic is written as
> `traverseWorkspaces` in `X.StackSet`, and `mapWorkspaces` written atop
> that via `Identity`. The latter then replaces the sole use of
> `runOnWorkspaces`, condemning it to deprecation.

#### Commentary

  - The first commit has been tested for some months. The second is much newer, but has been running on my system with no issue.

  - The second commit is another kind of hygiene. It arose on account of ugliness I was forced to confront in writing the first, but beyond that, it's not strictly related. It could be split off, but it didn't seem to deserve a PR of its own.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: they appear to function as intended.

  - [x] I updated the `CHANGES.md` file
