### PR TITLE
Let the current screen win in the fight for dupes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
 
 ### Bug Fixes
 
+* Duplicated floats (e.g. from X.A.CopyToAll) no longer escape to inactive
+  screens.
+
 ## 0.17.2 (April 2, 2023)
 
 ### Bug Fixes

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -197,6 +197,7 @@ windows f = do
         let m   = W.floating ws
             flt = [(fw, scaleRationalRect viewrect r)
                     | fw <- filter (`M.member` m) (W.index this)
+                    , fw `notElem` vis
                     , Just r <- [M.lookup fw m]]
             vs = flt ++ rs
 


### PR DESCRIPTION
> `windows` generates mappings one screen at a time, starting with the
> current. Tracking the windows it's already generated mappings for,
> it excludes them from the tiles under consideration, hence supporting
> window duplication in a first-biased manner. This allows the current
> screen to win against any contenders and keep duplicated tiles within
> reach.
>
> However, it neglects to extend this treatment to floats; they end up
> mapped in a last-biased manner. Consequently, duplicated floats become
> very slippery, escaping to any inactive screen they can. This change
> rectifies that issue.
>
> See: xmonad/xmonad-contrib#797

**Disclaimer**: I haven't actually tested this yet, but I'd rather put it up now than let it stagnate until I get around to rebuilding my system xmonad.

It's not clear whether or not this change merits a changelog entry.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
