### PR TITLE
X.Operations: Apply size hints in floatLocation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@
 
 * `Tall` does not draw windows with zero area.
 
+* `XMonad.Operations.floatLocation` now applies size hints. This means windows
+  will snap to these hints as soon as they're floated (mouse move, keybinding).
+  Previously that only happened on mouse resize.
+
 ### Bug Fixes
 
 * Duplicated floats (e.g. from X.A.CopyToAll) no longer escape to inactive

--- a/src/XMonad/Operations.hs
+++ b/src/XMonad/Operations.hs
@@ -704,6 +704,7 @@ floatLocation w =
 
   where go = withDisplay $ \d -> do
           ws <- gets windowset
+          sh <- io $ getWMNormalHints d w
           wa <- io $ getWindowAttributes d w
           let bw = (fromIntegral . wa_border_width) wa
           point_sc <- pointScreen (fi $ wa_x wa) (fi $ wa_y wa)
@@ -718,13 +719,14 @@ floatLocation w =
               sr = screenRect . W.screenDetail $ sc
               x = (fi (wa_x wa) - fi (rect_x sr)) % fi (rect_width sr)
               y = (fi (wa_y wa) - fi (rect_y sr)) % fi (rect_height sr)
-              width  = fi (wa_width  wa + bw*2) % fi (rect_width sr)
-              height = fi (wa_height wa + bw*2) % fi (rect_height sr)
+              (width, height) = applySizeHintsContents sh (wa_width wa, wa_height wa)
+              rwidth  = fi (width + bw*2) % fi (rect_width sr)
+              rheight = fi (height + bw*2) % fi (rect_height sr)
               -- adjust x/y of unmanaged windows if we ignored or didn't get pointScreen,
               -- it might be out of bounds otherwise
               rr = if managed || point_sc `sr_eq` Just sc
-                  then W.RationalRect x y width height
-                  else W.RationalRect (0.5 - width/2) (0.5 - height/2) width height
+                  then W.RationalRect x y rwidth rheight
+                  else W.RationalRect (0.5 - rwidth/2) (0.5 - rheight/2) rwidth rheight
 
           return (W.screen sc, rr)
 


### PR DESCRIPTION
### Description

This is hopefully harmless with well-behaved clients and ordinary xmonad configs, and it enables using re-floating to apply size hints to existing windows. The only visible behaviour change I can foresee is that tiled windows (which ignore hints by default, unless X.L.LayoutHints is used) will now snap to size hints whenever they're floated (either via a keybinding or on mouseMoveWindow), whereas previously they'd only do so on mouseResizeWindow.

My use-case for this is the following: when I change fonts in my terminal, it updates its size hints and then sends a ConfigureRequestEvent to change its size to keep the number of rows and columns the same, and it also happens to reset the position to 0, 0. If it's tiled, that request is just ignored and hintsEventHook handles the layout refresh. If it happens to be floating, I want neither the move to 0, 0 nor the window size change to keep rows/colums, so I have a handleEventHook that ignores that ConfigureRequestEvent and just refloats the window, but I need a way to reapply size hints.

I could add a separate function that applies these hints to the floating RationalRect, but that seems like a lossy operation due to the Doubles in there. So I'd probably end up replicating most of the code from floatLocation, and then I might just improve that instead… 🙂

(I'll submit that custom ConfigureRequestEvent-ignoring hook to xmonad-contrib later.)

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've confirmed these changes don't belong in xmonad-contrib instead:  
        see the 3rd paragraph 🙂

  - [X] I've considered how to best test these changes (property, unit, manually, ...) and concluded:  
        Making sure this doesn't break anything involves using it with all sorts of X clients. I've been running this for about a week with no trouble, but I haven't run any Steam games or Libreoffices during this time, so it definitely needs more testing.

  - [x] I updated the `CHANGES.md` file - **TODO** I don't know what to say, yet.
