### PR TITLE
Clarify the use of `cabal.project`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -236,17 +236,18 @@ See also <https://www.haskell.org/cabal/#install-upgrade>.
 
 #### Create a New Project
 
-Let's create a cabal project.  Since we're already in the correct
-directory (`~/.config/xmonad`) with `xmonad` and `xmonad-contrib`
-subdirectories, we'll instruct cabal to use them.  Create a file named
-`cabal.project` containing:
+If you want to use `xmonad` or `xmonad-contrib` from git, you will need a
+`cabal.project` file. If you want to use both from [Hackage][], you should
+skip this step.
+
+Create a file named `cabal.project` containing:
 
 ```
 packages: */*.cabal
 ```
 
-(If you skip this step, cabal will use the latest releases from [Hackage][]
-instead.)
+(If you do this step without using [git] checkouts, you will get an error from
+cabal in the next step. Simply remove `cabal.project` and try again.)
 
 #### Install Everything
 


### PR DESCRIPTION
### Description

We've had a user show up in IRC who missed the parenthetical at the end of the `cabal.project` step in `INSTALL.md` and got an error trying to build from Hackage. I've rephrased that part of the instructions to make it clear that `cabal.project` is only needed when building from git.

Closes #454 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: documentation change

  - [ ] I updated the `CHANGES.md` file: N/A
