### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -256,7 +256,7 @@ libraries and then build the xmonad binary:
 
 ``` console
 $ cabal update
-$ cabal install --package-env=$HOME/.config/xmonad --lib xmonad xmonad-contrib
+$ cabal install --package-env=$HOME/.config/xmonad --lib base xmonad xmonad-contrib
 $ cabal install --package-env=$HOME/.config/xmonad xmonad
 ```
 


### PR DESCRIPTION
### Description

Patchup for cabal 3.10, which broke environment files: you now have to install `base` and any other dependencies explicitly.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: N/A

  - [ ] I updated the `CHANGES.md` file: N/A
