### PR TITLE
Fix typo in TUTORIAL.md

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -268,7 +268,7 @@ myLayout = tiled ||| Mirror tiled ||| Full
 ```
 
 The so-called `where`-clause above simply consists of local declarations
-that might clutter things up where they all declared at the top-level
+that might clutter things up were they all declared at the top-level
 like this
 
 ``` haskell


### PR DESCRIPTION
### Description

Fix typo in TUTORIAL.md

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: No tests needed.

  - [ ] I updated the `CHANGES.md` file
