### PR TITLE
Move `unGrab` to `XMonad.Operations`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@
 * Recompilation now detects `flake.nix` and `default.nix` (can be a
   symlink) and switches to using `nix build` as appropriate.
 
+* Added `unGrab` to `XMonad.Operations`; this releases XMonad's passive
+  keyboard grab, so other applications (like `scrot`) can do their
+  thing.
+
 ### Bug Fixes
 
 * Duplicated floats (e.g. from X.A.CopyToAll) no longer escape to inactive


### PR DESCRIPTION
### Description

Moves the `XMonad.Util.Ungrab`'s code (the `unGrab` function) into `XMonad.Operations`.
Resolves #101 

Unfortunately will require a fix on `xmonad-contrib`, since it causes an ambiguous reference on `XMonad.Config.Mate`


### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: No tests added (there were none on xmonad-contrib). Tested manually with a config that uses unGrab and removed the `XMonad.Util.Ungrab` import.

  - [X] I updated the `CHANGES.md` file
