### PR TITLE
Add details to ManageHook.hs docs

### DIFF
--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -64,7 +64,8 @@ x <&&> y = ifM x y (pure False)
 (<||>) :: Monad m => m Bool -> m Bool -> m Bool
 x <||> y = ifM x (pure True) y
 
--- | Return the window title.
+-- | Return the window title; i.e., the string returned by @_NET_WM_NAME@,
+-- or failing that, the string returned by @WM_NAME@.
 title :: Query String
 title = ask >>= \w -> liftX $ do
     d <- asks display
@@ -91,7 +92,7 @@ className :: Query String
 className = ask >>= (\w -> liftX $ withDisplay $ \d -> fmap resClass $ io $ getClassHint d w)
 
 -- | A query that can return an arbitrary X property of type 'String',
---   identified by name.
+-- identified by name. Works for ASCII strings only.
 stringProperty :: String -> Query String
 stringProperty p = ask >>= (\w -> liftX $ withDisplay $ \d -> fromMaybe "" <$> getStringProperty d w p)
 

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -92,7 +92,9 @@ className :: Query String
 className = ask >>= (\w -> liftX $ withDisplay $ \d -> fmap resClass $ io $ getClassHint d w)
 
 -- | A query that can return an arbitrary X property of type 'String',
--- identified by name. Works for ASCII strings only.
+-- identified by name. Works for ASCII strings only. For the properties
+-- @_NET_WM_NAME@/@WM_NAME@ and @WM_CLASS@ the specialised variants 'title'
+-- and 'appName'/'className' are prefered.
 stringProperty :: String -> Query String
 stringProperty p = ask >>= (\w -> liftX $ withDisplay $ \d -> fromMaybe "" <$> getStringProperty d w p)
 

--- a/src/XMonad/ManageHook.hs
+++ b/src/XMonad/ManageHook.hs
@@ -94,7 +94,7 @@ className = ask >>= (\w -> liftX $ withDisplay $ \d -> fmap resClass $ io $ getC
 -- | A query that can return an arbitrary X property of type 'String',
 -- identified by name. Works for ASCII strings only. For the properties
 -- @_NET_WM_NAME@/@WM_NAME@ and @WM_CLASS@ the specialised variants 'title'
--- and 'appName'/'className' are prefered.
+-- and 'appName'/'className' are preferred.
 stringProperty :: String -> Query String
 stringProperty p = ask >>= (\w -> liftX $ withDisplay $ \d -> fromMaybe "" <$> getStringProperty d w p)
 


### PR DESCRIPTION
### Description

Add relevant information about `title` and `stringProperty` as discussed in #503.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file

Well, if you think, I shall test these doc changes or update the `CHANGES.md`, please tell me.