### PR TITLE
fix: deprecated url literals

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
 # See xmonad-contrib/NIX.md for an overview of module usage.
 {
   inputs = {
-    flake-utils.url = github:numtide/flake-utils;
-    git-ignore-nix.url = github:hercules-ci/gitignore.nix/master;
-    unstable.url = github:NixOS/nixpkgs/nixos-unstable;
+    flake-utils.url = "github:numtide/flake-utils";
+    git-ignore-nix.url = "github:hercules-ci/gitignore.nix/master";
+    unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
   outputs = { self, flake-utils, nixpkgs, unstable, git-ignore-nix }:
   let


### PR DESCRIPTION

### Description

Nix url litterals are being deprecated, this fixes failures on newer version.

I'm not sure we want this in changes but LMK and I will fix.

See: https://github.com/xmonad/xmonad-contrib/pull/904

Signed-off-by: Christina Sørensen <christina@cafkafk.com>

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
