### PR TITLE
Add recompilation support via `cabal`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ### Breaking Changes
 
+ * Use `cabal` for `--recompile` if there is a `.cabal` file in the config
+   directory and none of `build`, `stack.yaml`, `flake.nix`, nor `default.nix`
+   exist.
+
 ### Enhancements
 
 ### Bug Fixes


### PR DESCRIPTION
### Description

Use `cabal` for `--recompile` if there is a `.cabal` file in the config directory and none of `build`, `stack.yaml`, `flake.nix`, nor `default.nix` exist.

- This allows you to e.g. put your source files into `src` instead of `lib`, use `default-extensions`, etc.  As long as your config works with `cabal build` you are good to go.
- `cabal.project` is fully supported, but not required.
- You can split up your config into sub packages or reference GitHub dependencies, etc.


### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I tested this manually.  Some of the things could benefit from unit tests, but I think we don't have infrastructure for this in place.

  - [x] I updated the `CHANGES.md` file
