### PR TITLE
Update cabal install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -262,7 +262,7 @@ $ cabal install --package-env=$HOME/.config/xmonad xmonad
 
 This will create a GHC environment in `~/.config/xmonad` so that the libraries
 are available for recompilation of the config file, and also install the
-xmonad binary to `~/.cabal/bin/xmonad`.  Make sure you have that directory in
+xmonad binary to `~/.local/bin/xmonad`.  Make sure you have that directory in
 your `$PATH`!
 
 If you're getting build failures while building the `X11` package it may


### PR DESCRIPTION
### Description

Since `cabal` 3.10 executables are put in `~/.local/bin`.

GHCup recommends 3.14 now so, there is little reason to keep the old location.


### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: no tests.

  - [x] ~~I updated the `CHANGES.md` file.~~ I did not, because the change is trivial and does not modify `xmonad` behaviour. If it is necessary, I will do it.
