### PR TITLE
Pure layout support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@
 
 ### Enhancements
 
+ * Addition of `PureLayout` typeclass for `Layout` types which can work without
+   any X communications. This is intended to allow XMonad's layouts to be used
+   in other pluggable windowing systems (e.g., `river` and its external tiling
+   support).
+
 ### Bug Fixes
 
 ### Other

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -169,7 +169,7 @@ newtype ScreenDetail = SD { screenRect :: Rectangle }
 -- instantiated on 'XConf' and 'XState' automatically.
 --
 newtype X a = X (ReaderT XConf (StateT XState IO) a)
-    deriving (Functor, Applicative, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf)
+    deriving (Functor, Applicative, Monad, MonadFail, MonadIO, MonadState XState, MonadReader XConf) via ReaderT XConf (StateT XState IO)
     deriving (Semigroup, Monoid) via Ap X a
 
 instance Default a => Default (X a) where

--- a/src/XMonad/Core.hs
+++ b/src/XMonad/Core.hs
@@ -29,6 +29,7 @@ module XMonad.Core (
     X, WindowSet, WindowSpace, WorkspaceId,
     ScreenId(..), ScreenDetail(..), XState(..),
     XConf(..), XConfig(..), LayoutClass(..),
+    Pure(..), PureLayout(..),
     Layout(..), readsLayout, Typeable, Message,
     SomeMessage(..), fromMessage, LayoutMessages(..),
     StateExtension(..), ExtensionClass(..), ConfExtension(..),
@@ -256,6 +257,29 @@ data Layout a = forall l. (LayoutClass l a, Read (l a)) => Layout (l a)
 readsLayout :: Layout a -> String -> [(Layout a, String)]
 readsLayout (Layout l) s = [(Layout (asTypeOf x l), rs) | (x, rs) <- reads s]
 
+newtype Pure l a = MkPure (l a)
+    deriving (Show, Typeable)
+
+class (Show (layout a), Typeable layout) => PureLayout layout a where
+
+    -- | This is a pure version of 'doLayout', for cases where we
+    -- don't need access to the 'X' monad to determine how to lay out
+    -- the windows, and we don't need to modify the layout itself.
+    pureLayout'  :: layout a -> Rectangle -> Stack a -> [(a, Rectangle)]
+    pureLayout' _ r s = [(focus s, r)]
+
+    -- | Respond to a message by (possibly) changing our layout, but
+    -- taking no other action.  If the layout changes, the screen will
+    -- be refreshed.
+    pureMessage' :: layout a -> SomeMessage -> Maybe (layout a)
+    pureMessage' _ _  = Nothing
+
+    -- | This should be a human-readable string that is used when
+    -- selecting layouts by name.  The default implementation is
+    -- 'show', which is in some cases a poor default.
+    description' :: layout a -> String
+    description'      = show
+
 -- | Every layout must be an instance of 'LayoutClass', which defines
 -- the basic layout operations along with a sensible default for each.
 --
@@ -344,6 +368,11 @@ class (Show (layout a), Typeable layout) => LayoutClass layout a where
     -- 'show', which is in some cases a poor default.
     description :: layout a -> String
     description      = show
+
+instance (PureLayout layout a) => LayoutClass (Pure layout) a where
+    pureLayout (MkPure l) = pureLayout' l
+    pureMessage (MkPure l) = fmap MkPure . pureMessage' l
+    description (MkPure l) = description' l
 
 instance LayoutClass Layout Window where
     runLayout (Workspace i (Layout l) ms) r = fmap (fmap Layout) `fmap` runLayout (Workspace i l ms) r

--- a/src/XMonad/Layout.hs
+++ b/src/XMonad/Layout.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingVia #-}
 
 -- --------------------------------------------------------------------------
 -- |
@@ -48,12 +50,10 @@ instance Message IncMasterN
 
 -- | Simple fullscreen mode. Renders the focused window fullscreen.
 data Full a = Full deriving (Show, Read)
+    -- deriving LayoutClass via (Pure Full)
 
 instance PureLayout Full a
-instance LayoutClass Full a where
-    pureLayout = pureLayout'
-    pureMessage = pureMessage
-    description = description'
+deriving via Pure Full a instance LayoutClass Full a
 
 -- | The builtin tiling mode of xmonad. Supports 'Shrink', 'Expand' and
 -- 'IncMasterN'.
@@ -84,10 +84,7 @@ instance PureLayout Tall a where
 
     description' _ = "Tall"
 
-instance LayoutClass Tall a where
-    pureLayout = pureLayout'
-    pureMessage = pureMessage'
-    description = description'
+deriving via Pure Tall a instance LayoutClass Tall a
 
 -- | Compute the positions for windows using the default two-pane tiling
 -- algorithm.


### PR DESCRIPTION
### Description

Split out a `PureLayout` typeclass. This will allow such layouts to work on abstract windows (e.g., to tile windows on behalf of `river`).

---

Currently looking at trying to improve the `LayoutClass` implementation for `PureLayout` types. Haven't been able to get `deriving via` to work, mostly due to kind mismatches.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file
