### PR TITLE
add Hécate's Get Tested

### DIFF
--- a/.github/workflows/get-tested.yml
+++ b/.github/workflows/get-tested.yml
@@ -1,0 +1,345 @@
+name: Get Tested!
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: candidate version (must match version in cabal file)
+
+env:
+  GHC_FOR_UPLOAD: 9.8
+  CABAL_VERSION: 3.16.1.0
+  GHCUP_VERSION: 0.1.50.1
+
+jobs:
+  generate-matrix:
+    name: "Generate matrix from cabal file"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.9.1
+        with:
+          cabal-file: xmonad.cabal
+          ubuntu-version: "24.04"
+
+  generate-prefix:
+    name: Hack to generate release prefix
+    outputs:
+      prefix: ${{ steps.set-prefix.outputs.prefix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set release version prefix (hack)
+        id: set-prefix
+        run: echo "prefix=${{ env.GHC_FOR_UPLOAD }}." >> "$GITHUB_OUTPUT"
+
+  tests:
+    name: on ghc-${{ matrix.ghc }}
+    needs: [generate-matrix, generate-prefix]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes:
+      60
+    container:
+      image: buildpack-deps:jammy
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - name: apt-get install
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y libx11-dev libxext-dev libxinerama-dev libxrandr-dev libxss-dev
+
+      - name: Install GHCup
+        run: |
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/$GHCUP_VERSION/x86_64-linux-ghcup-$GHCUP_VERSION > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal $CABAL_VERSION || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-$CABAL_VERSION -vnormal+nowrap" >> "$GITHUB_ENV"
+
+      - name: Install GHC (GHCup)
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          # @@@ split the compiler name? need to see if GT supports non-ghc. not that we do.
+          HCKIND: ghc
+          HCNAME: ghc-${{ matrix.ghc }}
+          HCVER: ${{ matrix.ghc }}
+
+      - name: Set PATH and environment variables
+        run: |
+          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ghc
+          HCNAME: ghc-${{ matrix.ghc }}
+          HCVER: ${{ matrix.ghc }}
+
+      - name: env
+        run: |
+          env
+
+      - name: write cabal config
+        run: |
+          mkdir -p $CABAL_DIR
+          cat >> $CABAL_CONFIG <<EOF
+          remote-build-reporting: anonymous
+          write-ghc-environment-files: never
+          remote-repo-cache: $CABAL_DIR/packages
+          logs-dir:          $CABAL_DIR/logs
+          world-file:        $CABAL_DIR/world
+          extra-prog-path:   $CABAL_DIR/bin
+          symlink-bindir:    $CABAL_DIR/bin
+          installdir:        $CABAL_DIR/bin
+          build-summary:     $CABAL_DIR/logs/build.log
+          store-dir:         $CABAL_DIR/store
+          install-dirs user
+            prefix: $CABAL_DIR
+          repository hackage.haskell.org
+            url: http://hackage.haskell.org/
+          EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
+          EOF
+          cat $CABAL_CONFIG
+
+      - name: versions
+        run: |
+          $HC --version || true
+          $HC --print-project-git-commit-id || true
+          $CABAL --version || true
+
+      - name: update cabal index
+        run: |
+          $CABAL v2-update -v
+
+      - name: install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+          cabal-plan --version
+
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          path: source
+
+      - name: initial cabal.project for sdist
+        run: |
+          touch cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
+          cat cabal.project
+
+      - name: sdist
+        run: |
+          mkdir -p sdist
+          $CABAL sdist all --output-dir $GITHUB_WORKSPACE/sdist
+
+      - name: unpack
+        run: |
+          mkdir -p unpacked
+          find sdist -maxdepth 1 -type f -name '*.tar.gz' -exec tar -C $GITHUB_WORKSPACE/unpacked -xzvf {} \;
+
+      - name: generate cabal.project
+        run: |
+          PKGDIR_xmonad="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/xmonad-[0-9.]*')"
+          echo "PKGDIR_xmonad=${PKGDIR_xmonad}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
+          touch cabal.project
+          touch cabal.project.local
+          echo "packages: ${PKGDIR_xmonad}" >> cabal.project
+          echo "package xmonad" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          cat >> cabal.project <<EOF
+          optimization: False
+
+          package xmonad
+            flags: +pedantic
+          EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(xmonad)$/; }' >> cabal.project.local
+          cat cabal.project
+          cat cabal.project.local
+
+      - name: dump install plan
+        run: |
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
+          cabal-plan
+
+      - name: restore cache
+        uses: actions/cache/restore@v5
+        with:
+          # @@@ renamed to avoid collision with HCI; change if-when that's removed. Also in save below!
+          key: GT-${{ runner.os }}-ghc-${{ matrix.ghc }}-${{ github.sha }}
+          path: ~/.cabal/store
+          restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
+
+      - name: install dependencies
+        run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dependencies-only -j2 all
+
+      - name: build w/o tests
+        run: |
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+
+      - name: build
+        run: |
+          $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+
+      - name: tests
+        run: |
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+
+      - name: cabal check
+        run: |
+          cd ${PKGDIR_xmonad} || false
+          ${CABAL} -vnormal check
+
+      - name: haddock
+        run: |
+          $CABAL v2-haddock --disable-documentation $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+
+      - name: haddock for hackage
+        if: startsWith(matrix.ghc, needs.generate-prefix.outputs.prefix)
+        run: |
+          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH --haddock-for-hackage --builddir $GITHUB_WORKSPACE/haddock all
+
+      - name: unconstrained build
+        run: |
+          rm -f cabal.project.local
+          $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+
+      - name: save cache
+        if: always()
+        uses: actions/cache/save@v5
+        with:
+          # @@@ renamed as above
+          key: GT-${{ runner.os }}-ghc-${{ matrix.ghc }}-${{ github.sha }}
+          path: ~/.cabal/store
+
+      # must be separate artifacts because GitHub Actions are still broken:
+      # https://github.com/actions/upload-artifact/issues/441
+      # https://github.com/actions/upload-artifact/issues/457
+      - name: upload artifact (sdist)
+        if: startsWith(matrix.ghc, needs.generate-prefix.outputs.prefix)
+        uses: actions/upload-artifact@v6
+        with:
+          name: sdist
+          path: ${{ github.workspace }}/sdist/*.tar.gz
+      - name: upload artifact (haddock)
+        if: startsWith(matrix.ghc, needs.generate-prefix.outputs.prefix)
+        uses: actions/upload-artifact@v6
+        with:
+          name: haddock
+          path: ${{ github.workspace }}/haddock/*-docs.tar.gz
+
+      - name: hackage upload (candidate)
+        if: false && startsWith(matrix.ghc, needs.generate-prefix.outputs.prefix) && github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
+        shell: bash
+        run: |
+          set -ex
+          PACKAGE_VERSION="${PACKAGE_VERSION#v}"
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
+              https://hackage.haskell.org/packages/candidates/
+          )
+          [[ $res == 2?? ]]  # TODO: --fail-with-body once curl 7.76.0 is available
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              -X PUT \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --header "Content-Type: application/x-tar" \
+              --header "Content-Encoding: gzip" \
+              --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
+              https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/candidate/docs
+          )
+          [[ $res == 2?? ]]
+        env:
+          HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
+          PACKAGE_NAME: ${{ github.event.repository.name }}
+          PACKAGE_VERSION: ${{ github.event.inputs.version }}
+
+      - name: hackage upload (release)
+        if: false && startsWith(matrix.ghc, needs.generate-prefix.outputs.prefix) && github.event_name == 'release'
+        shell: bash
+        run: |
+          set -ex
+          PACKAGE_VERSION="${PACKAGE_VERSION#v}"
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --form package=@"${GITHUB_WORKSPACE}/sdist/${PACKAGE_NAME}-${PACKAGE_VERSION}.tar.gz" \
+              https://hackage.haskell.org/packages/
+          )
+          [[ $res == 2?? ]]  # TODO: --fail-with-body once curl 7.76.0 is available
+          res=$(
+            curl \
+              --silent --show-error --output /dev/stderr --write-out '%{http_code}' \
+              -X PUT \
+              --header "Accept: text/plain" \
+              --header "Authorization: X-ApiKey $HACKAGE_API_KEY" \
+              --header "Content-Type: application/x-tar" \
+              --header "Content-Encoding: gzip" \
+              --data-binary @"${GITHUB_WORKSPACE}/haddock/${PACKAGE_NAME}-${PACKAGE_VERSION}-docs.tar.gz" \
+              https://hackage.haskell.org/package/${PACKAGE_NAME}-${PACKAGE_VERSION}/docs
+          )
+          [[ $res == 2?? ]]
+        env:
+          HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
+          PACKAGE_NAME: ${{ github.event.repository.name }}
+          PACKAGE_VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
### Description

Start replacing Haskell-CI, which has been more of a problem than a solution of late, with @Kleidukos's Get Tested!. This is a functional first cut, but will probably want more work in the future since Get Tested! doesn't do some things Haskell-CI does.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: everything but Hackage releases tested, obviously;
        someone should test release candidates next time we make a release (see note below)

  - [ ] I updated the `CHANGES.md` file (not user visible, CI only)

### Comments

  - I didn't clean up the generated build steps I copied from Haskell-CI; there's some optimization that could be done.
  - The candidate and release actions are disabled (`if: false &&`) so they don't get triggered inadvertently. Remember to change these if we decide to test or switch to this.
