### PR TITLE
INSTALL, TUTORIAL: Update freedesktop.org links

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -390,7 +390,7 @@ if your xmonad configuration resides within `~/.xmonad`, then the
 executable will also be within that directory and not in
 `$XDG_CACHE_HOME`.
 
-[XDG]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+[XDG]: https://specifications.freedesktop.org/basedir/latest/
 [git]: https://git-scm.com/
 [stack]: https://docs.haskellstack.org/en/stable/README/
 [cabal-install]: https://www.haskell.org/cabal/

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1283,7 +1283,7 @@ either :)
 
 
 [log]: https://ircbrowse.tomsmeding.com/browse/lcxmonad
-[EWMH]: https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html
+[EWMH]: https://specifications.freedesktop.org/wm/latest/
 [ICCCM]: https://tronche.com/gui/x/icccm/
 [webchat]: https://web.libera.chat/#xmonad
 [about xmonad]: https://xmonad.org/about.html


### PR DESCRIPTION
### Description

The freedesktop.org specifications have moved.
This PR updates the relevant links in the files `INSTALL.md` and `TUTORIAL.md`.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've confirmed these changes don't belong in xmonad-contrib instead

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: N/A

  - [ ] I updated the `CHANGES.md` file
