### PR TITLE
nix: Link libXcursor at runtime

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,14 @@
         ${root} = recursiveUpdate prev.${root} (setAttrByPath branch hpkgs');
       };
     hoverlay = final: prev: hself: hsuper:
-      with prev.haskell.lib.compose; {
-        xmonad = hself.callCabal2nix "xmonad"
-          (git-ignore-nix.lib.gitignoreSource ./.) { };
+      with prev.haskell.lib.compose;
+      let pkg = hself.callCabal2nix "xmonad" (git-ignore-nix.lib.gitignoreSource ./.) { };
+          libXcursor = final.libxcursor or final.xorg.libXcursor;
+      in {
+        xmonad =
+          if final.stdenv.hostPlatform.isLinux
+          then addExtraLibrary libXcursor (enableCabalFlag "xcursor" pkg)
+          else pkg;
       };
     defComp = if builtins.pathExists ./comp.nix
       then import ./comp.nix

--- a/xmonad.cabal
+++ b/xmonad.cabal
@@ -54,6 +54,11 @@ flag pedantic
   default:     False
   manual:      True
 
+flag xcursor
+  description: Link Xcursor
+  default:     False
+  manual:      True
+
 library
   exposed-modules: XMonad
                    XMonad.Config
@@ -90,6 +95,9 @@ library
     ghc-options:   -Werror
     if impl(ghc >= 9.10)
        ghc-options: -Wno-incomplete-record-selectors
+
+  if flag(xcursor)
+    extra-libraries: Xcursor
 
 executable xmonad
   main-is:       Main.hs


### PR DESCRIPTION
### Description

Fixes: https://github.com/xmonad/xmonad/issues/565

I wasn't sure whether creating a new cabal flag is necessary, but I haven't found a way around it.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've confirmed these changes don't belong in xmonad-contrib instead

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manual test tells me the issue is gone

  - [n/a] I updated the `CHANGES.md` file
